### PR TITLE
Migrade eslint rules to @stylistic

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -183,9 +183,7 @@ module.exports = {
 
 		'@stylistic/array-bracket-newline': [
 			'error',
-			{
-				multiline: true,
-			},
+			'consistent',
 		],
 		'@stylistic/array-bracket-spacing': [
 			'error',
@@ -261,7 +259,10 @@ module.exports = {
 				SwitchCase: 1,
 				ignoredNodes: [
 					// Ignore indentation within template literals to allow them to be indented like markup
-					"TemplateLiteral *",
+					'TemplateLiteral *',
+					// This rule doesn't behave correctly for TypeScript generic types
+					// https://github.com/typescript-eslint/typescript-eslint/issues/455#issuecomment-560585408
+					'TSTypeParameterInstantiation ',
 				],
 			},
 		],
@@ -270,6 +271,7 @@ module.exports = {
 			{
 				'beforeColon': false,
 				'afterColon': true,
+				mode: 'minimum',
 			},
 		],
 		'@stylistic/keyword-spacing': [
@@ -413,10 +415,6 @@ module.exports = {
 			'error',
 			'prefer-double',
 		],
-		'@stylistic/jsx-curly-newline': [
-			'error',
-			'consistent',
-		],
 		'@stylistic/jsx-equals-spacing': [
 			'error',
 			'never',
@@ -431,9 +429,6 @@ module.exports = {
 				maximum: 1,
 				when: 'multiline',
 			},
-		],
-		'@stylistic/jsx-props-no-multi-spaces': [
-			'error',
 		],
 		'@stylistic/jsx-self-closing-comp': [
 			'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,10 +5,11 @@ module.exports = {
 		es2021: true,
 		node: false,
 	},
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
+	plugins: [
+		'@stylistic',
+		'@typescript-eslint',
+		'react',
+		'react-hooks',
 	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -20,10 +21,10 @@ module.exports = {
 			'./scripts/tsconfig.json',
 		],
 	},
-	plugins: [
-		'@typescript-eslint',
-		'react',
-		'react-hooks',
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 	],
 	settings: {
 		// Copied from `eslint-config-preact` (which is too opinionated for me to use, e.g. assumes Jest globals)
@@ -116,6 +117,19 @@ module.exports = {
 			}
 		],
 
+		///////////////////////////////
+		// TypeScript-specific rules //
+		///////////////////////////////
+		'@typescript-eslint/consistent-type-assertions': [
+			'error',
+			{
+				assertionStyle: 'as',
+			},
+		],
+		'@typescript-eslint/explicit-module-boundary-types': [
+			'error'
+		],
+
 		////////////////////////
 		// Preact / JSX Rules //
 		////////////////////////
@@ -156,33 +170,54 @@ module.exports = {
 		////////////////
 		// Code style //
 		////////////////
-		'array-bracket-spacing': [
+		'curly': [
+			'error',
+			'all',
+		],
+		'default-case-last': 'error',
+		'no-var': 'error',
+		'one-var': [
 			'error',
 			'never',
 		],
-		'arrow-parens': [
+
+		'@stylistic/array-bracket-newline': [
+			'error',
+			{
+				multiline: true,
+			},
+		],
+		'@stylistic/array-bracket-spacing': [
+			'error',
+			'never',
+		],
+		'@stylistic/array-element-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/arrow-parens': [
 			'error',
 			'always',
 		],
-		'arrow-spacing': [
+		'@stylistic/arrow-spacing': [
 			'error',
 			{
 				before: true,
 				after: true,
 			},
 		],
-		'block-spacing': [
+		'@stylistic/block-spacing': [
 			'error',
 			'always',
 		],
-		'brace-style': [
+		'@stylistic/brace-style': [
 			'error',
 			'1tbs',
 			{
 				allowSingleLine: true,
 			},
 		],
-		'comma-dangle': [
+		'@stylistic/comma-dangle': [
 			'error',
 			{
 				arrays: 'always-multiline',
@@ -192,31 +227,34 @@ module.exports = {
 				functions: 'only-multiline',
 			},
 		],
-		'comma-spacing': [
+		'@stylistic/comma-spacing': [
 			'error',
 			{
 				before: false,
 				after: true,
 			}
 		],
-		'comma-style': [
+		'@stylistic/comma-style': [
 			'error',
 			'last',
 		],
-		'curly': [
-			'error',
-			'all',
-		],
-		'default-case-last': 'error',
-		'eol-last': [
+		'@stylistic/eol-last': [
 			'error',
 			'always',
 		],
-		'func-call-spacing': [
+		'@stylistic/func-call-spacing': [
 			'error',
 			'never',
 		],
-		'indent': [
+		'@stylistic/function-call-argument-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/function-paren-newline': [
+			'error',
+			'multiline-arguments',
+		],
+		'@stylistic/indent': [
 			'error',
 			'tab',
 			{
@@ -227,47 +265,79 @@ module.exports = {
 				],
 			},
 		],
-		// My IDE handles this, it's annoying to see the squigly lines appear
-		'no-trailing-spaces': [
-			'off',
-		],
-		'no-var': 'error',
-		'one-var': [
+		'@stylistic/key-spacing': [
 			'error',
-			'never',
+			{
+				'beforeColon': false,
+				'afterColon': true,
+			},
 		],
-		'quotes': [
+		'@stylistic/keyword-spacing': [
+			'error',
+			{
+				'before': true,
+				'after': true,
+			},
+		],
+		'@stylistic/multiline-ternary': [
+			'error',
+			'always-multiline',
+		],
+		'@stylistic/new-parens': [
+			'error',
+			'always',
+		],
+		'@stylistic/no-extra-semi': [
+			'error',
+		],
+		'@stylistic/no-mixed-spaces-and-tabs': [
+			'error',
+			'smart-tabs',
+		],
+		'@stylistic/no-trailing-spaces': [
+			'error',
+		],
+		'@stylistic/no-whitespace-before-property': [
+			'error',
+		],
+		'@stylistic/object-curly-newline': [
+			'error',
+			{
+				multiline: true,
+				consistent: true,
+			},
+		],
+		'@stylistic/quotes': [
 			'error',
 			'single',
 			{
 				allowTemplateLiterals: true,
 			},
 		],
-		'rest-spread-spacing': [
+		'@stylistic/rest-spread-spacing': [
 			'error',
 			'never',
 		],
-		'semi': [
+		'@stylistic/semi': [
 			'error',
 			'always',
 		],
-		'semi-spacing': [
+		'@stylistic/semi-spacing': [
 			'error',
 			{
 				before: false,
 				after: true,
 			},
 		],
-		'semi-style': [
+		'@stylistic/semi-style': [
 			'error',
 			'last',
 		],
-		'space-before-blocks': [
+		'@stylistic/space-before-blocks': [
 			'error',
 			'always',
 		],
-		'space-before-function-paren': 'off',
-		'@typescript-eslint/space-before-function-paren': [
+		'@stylistic/space-before-function-paren': [
 			'error',
 			{
 				anonymous: 'always',
@@ -275,17 +345,17 @@ module.exports = {
 				asyncArrow: 'always',
 			},
 		],
-		'space-in-parens': [
+		'@stylistic/space-in-parens': [
 			'error',
 			'never',
 		],
-		'space-unary-ops': [
+		'@stylistic/space-unary-ops': [
 			'error',
 			{
 				words: true,
 			},
 		],
-		'spaced-comment': [
+		'@stylistic/spaced-comment': [
 			'error',
 			'always',
 			{
@@ -297,20 +367,89 @@ module.exports = {
 				},
 			},
 		],
-		'no-mixed-spaces-and-tabs': [
-			'error',
-			'smart-tabs',
-		],
-
-		// TypeScript-specific rules
-		'@typescript-eslint/consistent-type-assertions': [
+		'@stylistic/switch-colon-spacing': [
 			'error',
 			{
-				assertionStyle: 'as',
+				'after': true,
+				'before': false,
 			},
 		],
-		'@typescript-eslint/explicit-module-boundary-types': [
-			'error'
+
+		// TypeScript-specific code style rules
+		'@stylistic/member-delimiter-style': [
+			'error',
+			{
+				multiline: {
+					delimiter: 'semi',
+					requireLast: true,
+				},
+				singleline: {
+					delimiter: 'semi',
+					requireLast: true,
+				},
+				multilineDetection: 'brackets',
+			},
+		],
+		'@stylistic/type-annotation-spacing': [
+			'error',
+			{
+				before: false,
+				after: true,
+				overrides: {
+					arrow: {
+						before: true,
+						after: true,
+					},
+				},
+			},
+		],
+
+		// JSX-specific code style rules
+		'@stylistic/jsx-closing-bracket-location': [
+			'error',
+			'line-aligned',
+		],
+		'@stylistic/jsx-quotes': [
+			'error',
+			'prefer-double',
+		],
+		'@stylistic/jsx-curly-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/jsx-equals-spacing': [
+			'error',
+			'never',
+		],
+		'@stylistic/jsx-first-prop-new-line': [
+			'error',
+			'multiline-multiprop',
+		],
+		'@stylistic/jsx-max-props-per-line': [
+			'error',
+			{
+				maximum: 1,
+				when: 'multiline',
+			},
+		],
+		'@stylistic/jsx-props-no-multi-spaces': [
+			'error',
+		],
+		'@stylistic/jsx-self-closing-comp': [
+			'error',
+			{
+				component: true,
+				html: true,
+			},
+		],
+		'@stylistic/jsx-tag-spacing': [
+			'error',
+			{
+				"closingSlash": "never",
+				"beforeSelfClosing": "always",
+				"afterOpening": "never",
+				"beforeClosing": "allow"
+			},
 		],
 	}
 };

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ These dependencies are used when working on the project locally.
 
 	* [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser): Allows `eslint` to parse TypeScript
 
+	* [@stylistic/eslint-plugin](https://eslint.style/): Provides linting rules to enforce code style
+
 	* [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react): Provides React/Preact linting rules
 
 	* [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks): Provides React/Preact linting rules

--- a/app/assets/js/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/app/assets/js/src/components/CommandPalette/CommandPalette.test.tsx
@@ -161,7 +161,7 @@ describe('CommandPalette', () => {
 		registerCommand('__TEST_COMMAND_B__', { name: 'Command 2' });
 		registerCommand('__TEST_COMMAND_C__', { name: 'Command 3' });
 
-		const { getByRole, rerender } = render(
+		const { getByRole } = render(
 			<CommandPalette
 				open
 				onClose={closeSpy}

--- a/app/assets/js/src/components/CommandPalette/CommandPaletteItemName.tsx
+++ b/app/assets/js/src/components/CommandPalette/CommandPaletteItemName.tsx
@@ -29,7 +29,7 @@ export function CommandPaletteItemName(props: CommandPaletteItemNameProps): JSX.
 	}
 
 	// Convert match into matched and unmatched tokens
-	const tokens: Array<{ string: string, match: boolean; }> = [];
+	const tokens: Array<{ string: string; match: boolean; }> = [];
 	let queryIndex = 0;
 	for (const token of match.slice(1)) {
 		// Step through groups, keeping track of our position in the query

--- a/app/assets/js/src/components/DayComponent.tsx
+++ b/app/assets/js/src/components/DayComponent.tsx
@@ -91,7 +91,8 @@ export const DayComponent = forwardRef(
 				if (tasksRef.current) {
 					// TODO: Is this the best way to find the right element?
 					const taskEditButtons = Array.from(
-						tasksRef.current.querySelectorAll<HTMLElement>('.js-task__name-edit') ?? []);
+						tasksRef.current.querySelectorAll<HTMLElement>('.js-task__name-edit') ?? []
+					);
 					const lastTaskEditButton = taskEditButtons.at(-1);
 
 					if (lastTaskEditButton) {

--- a/app/assets/js/src/components/shared/Toast.tsx
+++ b/app/assets/js/src/components/shared/Toast.tsx
@@ -96,13 +96,13 @@ type ToastOptions = Partial<Omit<ToastProps, 'message'>>;
 /**
  * Show a new toast with a specified message and duration.
  */
-export function toast(message: string, duration?: ToastProps['duration']): void
+export function toast(message: string, duration?: ToastProps['duration']): void;
 /**
  * Show a toast with a specified message. An ID can be passed to
  * create a toast that can be updated by calling this function again
  * with the same ID, if it still exists.
  */
-export function toast(message: string, options?: ToastOptions): void
+export function toast(message: string, options?: ToastOptions): void;
 export function toast(message: string, optionsArg?: ToastProps['duration'] | ToastOptions): void {
 	// Start by consolidating arguments
 	const options = typeof optionsArg === 'number' ? { duration: optionsArg } : { ...optionsArg };

--- a/app/assets/js/src/dom-lib/viewTransition.d.ts
+++ b/app/assets/js/src/dom-lib/viewTransition.d.ts
@@ -13,7 +13,7 @@ declare global {
 		startViewTransition?: (
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			callback: () => any
-		) => ViewTransition
+		) => ViewTransition;
 	}
 }
 

--- a/app/assets/js/src/registers/commands/fireCommand.ts
+++ b/app/assets/js/src/registers/commands/fireCommand.ts
@@ -9,7 +9,7 @@ import type { CommandId } from './types/CommandId';
  */
 type FireCommandArgs = {
 	[C in CommandId]: [command: C, ...args: CommandsList[C] | []];
-}[CommandId]
+}[CommandId];
 
 /**
  * Call all listeners bound to a specified command.

--- a/app/assets/js/src/registers/commands/getCommandInfo.ts
+++ b/app/assets/js/src/registers/commands/getCommandInfo.ts
@@ -11,13 +11,13 @@ import { commandsRegister } from './commandsRegister';
  */
 export function getCommandInfo(
 	command: CommandId
-): CommandInfo | null
+): CommandInfo | null;
 /**
  * Retrieves information about all registered commands.
  *
  * @returns An array of objects containing information about all registered commands.
  */
-export function getCommandInfo(): CommandInfo[]
+export function getCommandInfo(): CommandInfo[];
 export function getCommandInfo(
 	command?: CommandId
 ): CommandInfo[] | CommandInfo | null {

--- a/app/assets/js/src/registers/commands/hooks/useCommand.ts
+++ b/app/assets/js/src/registers/commands/hooks/useCommand.ts
@@ -10,7 +10,7 @@ type UseCommandArgs = {
 		command: C,
 		listener: (...args: CommandsList[C] | []) => void
 	]
-}[CommandId]
+}[CommandId];
 
 /**
  * Binds a listener to a specified command.

--- a/app/assets/js/src/registers/commands/hooks/useCommandInfo.ts
+++ b/app/assets/js/src/registers/commands/hooks/useCommandInfo.ts
@@ -9,13 +9,13 @@ import { getCommandInfo } from '../getCommandInfo';
 /**
  * Provides up to date information on all registered commands.
  */
-export function useCommandInfo(): CommandInfo[]
+export function useCommandInfo(): CommandInfo[];
 /**
  * Provides up to date information on a single registered command.
  *
  * @param command A string ID identifying a command.
  */
-export function useCommandInfo(command: CommandId): CommandInfo | null
+export function useCommandInfo(command: CommandId): CommandInfo | null;
 export function useCommandInfo(
 	command?: CommandId
 ): CommandInfo[] | CommandInfo | null {

--- a/app/assets/js/src/registers/commands/listeners/addCommandListener.ts
+++ b/app/assets/js/src/registers/commands/listeners/addCommandListener.ts
@@ -22,7 +22,7 @@ type RemoveCommandListenerArgs = {
 		command: C,
 		listener: (...args: CommandsList[C] | []) => void
 	];
-}[CommandId]
+}[CommandId];
 
 /**
  * The same discriminated union of tuples as in {@linkcode RemoveCommandListenerArgs},

--- a/app/assets/js/src/registers/commands/types/CommandRegistration.ts
+++ b/app/assets/js/src/registers/commands/types/CommandRegistration.ts
@@ -18,4 +18,4 @@ export type CommandRegistration<
 
 	/** All bound listeners that will be called when the command is fired. */
 	listeners: Set<(...args: CommandsList[C] | []) => void>;
-}
+};

--- a/app/assets/js/src/registers/days/daysRegister.ts
+++ b/app/assets/js/src/registers/days/daysRegister.ts
@@ -20,7 +20,7 @@ let loadDaysDataPromise: ReturnType<typeof loadDaysData> | null = null;
  * Otherwise, return already stored day data.
  */
 export async function loadDaysData(
-	options?: { signal: AbortSignal }
+	options?: { signal: AbortSignal; }
 ): Promise<ReadonlyArray<Readonly<Day>>> {
 	if (!isInitialised) {
 		if (loadDaysDataPromise) {

--- a/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
@@ -15,13 +15,13 @@ import { bindKeyboardShortcutToCommand } from '../listeners/bindKeyboardShortcut
 /**
  * Bind a callback to a keyboard shortcut, within a Preact component.
  */
-export function useKeyboardShortcut(name: KeyboardShortcutName, listener: () => void): void
+export function useKeyboardShortcut(name: KeyboardShortcutName, listener: () => void): void;
 /**
  * Bind a keyboard shortcut to fire a command, within a Preact component.
  *
  * For binding callbacks to commands, see {@linkcode useCommand}
  */
-export function useKeyboardShortcut(name: KeyboardShortcutName, command: CommandId): void
+export function useKeyboardShortcut(name: KeyboardShortcutName, command: CommandId): void;
 export function useKeyboardShortcut(
 	name: KeyboardShortcutName,
 	listenerOrCommand: (() => void) | CommandId,

--- a/app/assets/js/src/registers/tasks/tasksRegister.ts
+++ b/app/assets/js/src/registers/tasks/tasksRegister.ts
@@ -27,7 +27,7 @@ function getNextId(): number {
  * Otherwise, return already stored day data.
  */
 export async function loadTasksData(
-	options?: { signal: AbortSignal }
+	options?: { signal: AbortSignal; }
 ): Promise<ReadonlyArray<Readonly<Task>>> {
 	if (!isInitialised) {
 		if (loadTasksDataPromise) {
@@ -215,8 +215,8 @@ interface AddNewTaskOptions {
  *
  * Returns the ID of the new task
  */
-export function addNewTask(name?: string): number
-export function addNewTask(options?: AddNewTaskOptions): number
+export function addNewTask(name?: string): number;
+export function addNewTask(options?: AddNewTaskOptions): number;
 export function addNewTask(options?: string | AddNewTaskOptions): number {
 	// First, consolidate arguments
 	const name = (() => {

--- a/app/assets/js/src/util/DeepPartial.ts
+++ b/app/assets/js/src/util/DeepPartial.ts
@@ -18,10 +18,9 @@
  * ```
  */
 export type DeepPartial<T> = T extends object ? {
-	[P in keyof T]?:
-		T[P] extends Array<infer Inner>
-		? Array<DeepPartial<Inner>> :
-		T[P] extends ReadonlyArray<infer Inner>
-		? ReadonlyArray<DeepPartial<Inner>> :
-		DeepPartial<T[P]>;
+	[P in keyof T]?: T[P] extends Array<infer Inner>
+		? Array<DeepPartial<Inner>>
+		: T[P] extends ReadonlyArray<infer Inner>
+			? ReadonlyArray<DeepPartial<Inner>>
+			: DeepPartial<T[P]>;
 } : T;

--- a/app/assets/js/src/util/register/Register.ts
+++ b/app/assets/js/src/util/register/Register.ts
@@ -74,21 +74,21 @@ export class Register<K, V> {
 	 *
 	 * Event listeners for 'set' events.
 	 */
-	#setListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'set' }>[1]>;
+	#setListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'set'; }>[1]>;
 
 	/**
 	 * @internal
 	 *
 	 * Event listeners for 'delete' events.
 	 */
-	#deleteListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'delete' }>[1]>;
+	#deleteListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'delete'; }>[1]>;
 
 	/**
 	 * @internal
 	 *
 	 * Event listeners for 'change' events.
 	 */
-	#changeListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'change' }>[1]>;
+	#changeListeners: Set<Extract<RegisterEventBindingArguments<K, V>, { 0: 'change'; }>[1]>;
 
 	/**
 	 * Retrieve the value for a given key. If the key does not exist, returns `undefined`.

--- a/app/assets/js/src/util/register/useRegister.ts
+++ b/app/assets/js/src/util/register/useRegister.ts
@@ -11,7 +11,7 @@ import { Register } from './Register';
  */
 export function useRegister<K, V>(
 	register: Register<K, V>
-): readonly (readonly [K, V])[]
+): readonly (readonly [K, V])[];
 /**
  * A hook for observing changes to a specific key in a {@linkcode Register}.
  *
@@ -23,7 +23,7 @@ export function useRegister<K, V>(
 export function useRegister<K, V>(
 	register: Register<K, V>,
 	keyToObserve: K
-): V | undefined
+): V | undefined;
 export function useRegister<K, V>(
 	register: Register<K, V>,
 	keyToObserve?: K

--- a/app/assets/js/src/util/useAsyncData.ts
+++ b/app/assets/js/src/util/useAsyncData.ts
@@ -45,7 +45,7 @@ export function useAsyncData<T>(
 					}
 				})();
 				setError(error);
-			 } finally {
+			} finally {
 				setIsLoading(false);
 			}
 		})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 			},
 			"devDependencies": {
 				"@jest/globals": "^29.7.0",
+				"@stylistic/eslint-plugin": "^1.0.0",
 				"@testing-library/jest-dom": "^6.1.4",
 				"@testing-library/preact": "^3.2.3",
 				"@testing-library/user-event": "^14.5.1",
@@ -1815,6 +1816,62 @@
 			"dev": true,
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
+			"integrity": "sha512-kh4q2O2r55uKTXIQlVxnr9Pkjaemv/pn0lQ6bVRBD/ETq0hwhIvXR/54NRs3X8bS4IGIO2SGjFxnjySfUYJ3tQ==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "1.0.0",
+				"@stylistic/eslint-plugin-jsx": "1.0.0",
+				"@stylistic/eslint-plugin-ts": "1.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.0.0.tgz",
+			"integrity": "sha512-xxvjyYnUEgjBTnXKYMk6JbU0LHkf269d6y4IgW69bK/VwHrqLfdgE6mYvft42U7KVpp6Tbf6Z64tLRYD/rYd/A==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"acorn": "^8.10.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esutils": "^2.0.3",
+				"graphemer": "^1.4.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.0.0.tgz",
+			"integrity": "sha512-waUm7dcTFAI4d/3luf06RRNt89gSGaofHJ4BiuqKnpyu3yxn1lKbholjGQrw0xPjAciUe+ZSF6BKlBA9P2aV4Q==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "^1.0.0",
+				"estraverse": "^5.3.0",
+				"jsx-ast-utils": "^3.3.5"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-ts": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.0.0.tgz",
+			"integrity": "sha512-qQKXYWJzovSNsPq1954t6DNbDA7+1c4ximVH4CuubPV+3I8qCeO33vF6wSpyP27LgxXAx0mHIDw/YaaoM7dQoQ==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "1.0.0",
+				"@typescript-eslint/scope-manager": "^6.8.0",
+				"@typescript-eslint/type-utils": "^6.8.0",
+				"@typescript-eslint/utils": "^6.8.0",
+				"graphemer": "^1.4.0"
+			},
+			"peerDependencies": {
+				"eslint": "*"
 			}
 		},
 		"node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -6,24 +6,19 @@
 	"type": "module",
 	"scripts": {
 		"server": "ts-node --esm scripts/server.ts",
-
 		"buildJs": "concurrently \"tsc --noEmit\" \"ts-node --esm scripts/build.ts\"",
 		"buildCss": "sass app/assets/scss:app/assets/css",
 		"build": "concurrently \"npm run buildJs\" \"npm run buildCss\"",
-
 		"pretest": "tsc --noEmit",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
 		"testCoverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --collectCoverage",
-
 		"watchJs": "ts-node --esm scripts/build-watch.ts",
 		"watchCss": "sass app/assets/scss:app/assets/css --watch",
 		"testWatch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
 		"watch": "concurrently --kill-others \"tsc --watch --preserveWatchOutput --noEmit\" \"npm run watchJs\" \"npm run watchCss\" \"npm run testWatch\"",
-
 		"lintJs": "eslint app/assets/js/src/**",
 		"lintCss": "stylelint app/assets/scss/**/*.scss",
 		"lint": "npm run lintJs && npm run lintCss",
-
 		"start": "concurrently --kill-others \"npm run server\" \"npm run watch\"",
 		"prepare": "npm test"
 	},
@@ -35,6 +30,7 @@
 	"license": "Hippocratic-2.1",
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
+		"@stylistic/eslint-plugin": "^1.0.0",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/preact": "^3.2.3",
 		"@testing-library/user-event": "^14.5.1",

--- a/package.json
+++ b/package.json
@@ -6,19 +6,24 @@
 	"type": "module",
 	"scripts": {
 		"server": "ts-node --esm scripts/server.ts",
+
 		"buildJs": "concurrently \"tsc --noEmit\" \"ts-node --esm scripts/build.ts\"",
 		"buildCss": "sass app/assets/scss:app/assets/css",
 		"build": "concurrently \"npm run buildJs\" \"npm run buildCss\"",
+
 		"pretest": "tsc --noEmit",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
 		"testCoverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --collectCoverage",
+
 		"watchJs": "ts-node --esm scripts/build-watch.ts",
 		"watchCss": "sass app/assets/scss:app/assets/css --watch",
 		"testWatch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
 		"watch": "concurrently --kill-others \"tsc --watch --preserveWatchOutput --noEmit\" \"npm run watchJs\" \"npm run watchCss\" \"npm run testWatch\"",
+
 		"lintJs": "eslint app/assets/js/src/**",
 		"lintCss": "stylelint app/assets/scss/**/*.scss",
 		"lint": "npm run lintJs && npm run lintCss",
+
 		"start": "concurrently --kill-others \"npm run server\" \"npm run watch\"",
 		"prepare": "npm test"
 	},


### PR DESCRIPTION
ESLint is migrating its rules to [@stylistic](https://eslint.style/). This PR installs the plugin and updates the configuration to use its rules. I've also gone through the list of rules and configured a few more, including several JSX-specific style rules.

As well as updating the linting rules, this PR also fixes a few linting issues that were uncovered as part of the work.