### PR TITLE
Allow line breaks in markdown without any extra syntax

### DIFF
--- a/app/assets/js/src/components/shared/Markdown.test.tsx
+++ b/app/assets/js/src/components/shared/Markdown.test.tsx
@@ -15,7 +15,10 @@ describe('Markdown', () => {
 
 	test('renders its content, converted to HTML', () => {
 		const { getByTestId } = render(
-			<Markdown content="**Bold** *italic* `code`" />
+			<Markdown
+				content="**Bold** *italic* `code`"
+				data-testid="markdown-content"
+			/>
 		);
 
 		const content = getByTestId('markdown-content');
@@ -28,7 +31,10 @@ describe('Markdown', () => {
 	This is some code
 \`\`\``;
 		const { getByTestId } = render(
-			<Markdown content={text} />
+			<Markdown
+				content={text}
+				data-testid="markdown-content"
+			/>
 		);
 
 		const content = getByTestId('markdown-content');
@@ -44,12 +50,27 @@ describe('Markdown', () => {
 		expect(content).toBeInTheDocument();
 	});
 
+	test('allows line breaks without any extra syntax', () => {
+		const { getByTestId } = render(
+			<Markdown
+				content={`First line\nSecond line`}
+				data-testid="markdown-content"
+			/>
+		);
+
+		const content = getByTestId('markdown-content');
+		expect(content.innerHTML).toBe('<p>First line<br>Second line</p>\n');
+	});
+
 	test('passes through additional props to the internal `<div>`, adding CSS classes to its existing ones', async () => {
 		const user = userEvent.setup();
 		const spy = jest.fn();
 
 		const { getByTestId, rerender } = render(
-			<Markdown content="" />
+			<Markdown
+				content=""
+				data-testid="markdown-content"
+			/>
 		);
 
 		let content = getByTestId('markdown-content');
@@ -74,7 +95,10 @@ describe('Markdown', () => {
 
 	test('sanitises content', () => {
 		const { getByTestId } = render(
-			<Markdown content="<script>window.alert('xss')</script>" />
+			<Markdown
+				content="<script>window.alert('xss')</script>"
+				data-testid="markdown-content"
+			/>
 		);
 
 		const content = getByTestId('markdown-content');
@@ -90,6 +114,7 @@ this is the second line`;
 			<Markdown
 				content={content}
 				inline
+				data-testid="markdown-content"
 			/>
 		);
 

--- a/app/assets/js/src/components/shared/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown.tsx
@@ -42,7 +42,9 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 			: content;
 
 		let renderedContent = marked
-			.parse(contentToRender)
+			.parse(contentToRender, {
+				breaks: true,
+			})
 			// Stupid fucking plugin replaces tabs with spaces
 			.replace(/ {4}/g, '\t')
 			// To allow HTML tags to be written as text in task names,
@@ -65,7 +67,6 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 
 	return <div
 		ref={wrapperRef}
-		data-testid="markdown-content"
 		{...passthroughProps}
 		class={classNames('content', passthroughProps.class && String(passthroughProps.class))}
 	/>;


### PR DESCRIPTION
Resolves #21 