### PR TITLE
Keyboard shortcuts rework

### DIFF
--- a/app/assets/js/src/components/KeyboardShortcutsModal.tsx
+++ b/app/assets/js/src/components/KeyboardShortcutsModal.tsx
@@ -34,20 +34,22 @@ export function KeyboardShortcutModal(): JSX.Element {
 		title="Keyboard shortcuts"
 	>
 		<dl class="keyboard-shortcuts__list">
-			{keyboardShortcutsInfo.map((keyboardShortcutInfo) => (
-				<div
-					key={keyboardShortcutInfo.name}
-					class="keyboard-shortcuts__item"
-				>
-					<dt class="keyboard-shortcuts__item__name">{keyboardShortcutInfo.name}</dt>
+			{keyboardShortcutsInfo
+				.filter(({ shortcuts }) => shortcuts.length > 0)
+				.map((keyboardShortcutInfo) => (
+					<div
+						key={keyboardShortcutInfo.name}
+						class="keyboard-shortcuts__item"
+					>
+						<dt class="keyboard-shortcuts__item__name">{keyboardShortcutInfo.name}</dt>
 
-					<dd class="keyboard-shortcuts__item__combos">
-						<KeyboardShortcutCombos
-							keyboardShortcutName={keyboardShortcutInfo.name}
-						/>
-					</dd>
-				</div>
-			))}
+						<dd class="keyboard-shortcuts__item__combos">
+							<KeyboardShortcutCombos
+								keyboardShortcutName={keyboardShortcutInfo.name}
+							/>
+						</dd>
+					</div>
+				))}
 		</dl>
 	</Modal>;
 }

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -34,13 +34,34 @@ interface OrangeTwistProps {
 export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 	const { children } = props;
 
-	// Register all commands
+	// Register all commands and keyboard shortcuts
 	useEffect(() => {
 		registerCommand(Command.DATA_SAVE, { name: 'Save data' });
 		registerCommand(Command.DAY_ADD_NEW, { name: 'Add new day' });
 		registerCommand(Command.TASK_ADD_NEW, { name: 'Add new task' });
 		registerCommand(Command.THEME_TOGGLE, { name: 'Toggle theme' });
-	});
+
+		registerKeyboardShortcut(
+			KeyboardShortcutName.COMMAND_PALETTE_OPEN,
+			[{
+				key: '\\',
+			}],
+		);
+		registerKeyboardShortcut(
+			KeyboardShortcutName.DATA_SAVE,
+			[{
+				key: 's',
+				ctrl: true,
+			}],
+		);
+		registerKeyboardShortcut(
+			KeyboardShortcutName.EDITING_FINISH,
+			[
+				{ key: 'Enter', ctrl: true },
+				{ key: 'Escape' },
+			]
+		);
+	}, []);
 
 	/**
 	 * Toggle between task and light themes.
@@ -61,7 +82,6 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 		htmlEl.style.setProperty('--theme', newTheme);
 		localStorage.setItem('theme', newTheme);
 	}, []);
-
 	useCommand(Command.THEME_TOGGLE, toggleTheme);
 
 	// Open command palette on keyboard shortcut
@@ -75,12 +95,6 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 	const closeCommandPalette = useCallback(
 		() => setCommandPaletteOpen(false),
 		[]
-	);
-	registerKeyboardShortcut(
-		KeyboardShortcutName.COMMAND_PALETTE_OPEN,
-		[{
-			key: '\\',
-		}],
 	);
 	useKeyboardShortcut(KeyboardShortcutName.COMMAND_PALETTE_OPEN, openCommandPalette);
 
@@ -107,15 +121,6 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 		[]
 	);
 	useCommand(Command.DATA_SAVE, saveData);
-
-	// Set up save data keyboard shortcut
-	registerKeyboardShortcut(
-		KeyboardShortcutName.DATA_SAVE,
-		[{
-			key: 's',
-			ctrl: true,
-		}],
-	);
 	useKeyboardShortcut(KeyboardShortcutName.DATA_SAVE, Command.DATA_SAVE);
 
 	/**

--- a/app/assets/js/src/components/shared/Note.test.tsx
+++ b/app/assets/js/src/components/shared/Note.test.tsx
@@ -18,6 +18,8 @@ import {
 
 import userEvent from '@testing-library/user-event';
 
+import { KeyboardShortcutName, registerKeyboardShortcut } from 'registers/keyboard-shortcuts';
+
 import { Note } from './Note';
 
 beforeAll(() => {
@@ -170,8 +172,16 @@ describe('Note', () => {
 		expect(spy).toHaveBeenCalledWith('abcd');
 	});
 
-	test('leaves editing mode when pressing "Escape"', async () => {
+	test('leaves editing mode when pressing the "Finish editing" keyboard shortcut', async () => {
 		const user = userEvent.setup();
+
+		registerKeyboardShortcut(
+			KeyboardShortcutName.EDITING_FINISH,
+			[
+				{ key: 'Enter', ctrl: true },
+				{ key: 'Escape' },
+			]
+		);
 
 		const {
 			queryByRole,
@@ -186,40 +196,20 @@ describe('Note', () => {
 
 		const editButton = queryByTitle('Edit note')!;
 		await user.click(editButton);
-
-		expect(queryByRole('textbox')).toBeInTheDocument();
-
-		await user.keyboard('{Escape}');
-
-		expect(queryByRole('textbox')).not.toBeInTheDocument();
-	});
-
-	test('leaves editing mode when pressing "Ctrl + Enter"', async () => {
-		const user = userEvent.setup();
-
-		const {
-			queryByRole,
-			queryByTitle,
-		} = render(
-			<Note
-				note={null}
-				onNoteChange={() => {}}
-				saveChanges={() => {}}
-			/>
-		);
-
-		const editButton = queryByTitle('Edit note')!;
-		await user.click(editButton);
-
 		expect(queryByRole('textbox')).toBeInTheDocument();
 
 		// Pressing enter should not exit edit mode
 		await user.keyboard('{Enter}');
-
 		expect(queryByRole('textbox')).toBeInTheDocument();
 
+		// Pressing Ctrl + enter should exit edit mode
 		await user.keyboard('{Control>}{Enter}{/Control}');
+		expect(queryByRole('textbox')).not.toBeInTheDocument();
 
+		// Pressing escape should exit edit mode
+		await user.click(editButton);
+		expect(queryByRole('textbox')).toBeInTheDocument();
+		await user.keyboard('{Escape}');
 		expect(queryByRole('textbox')).not.toBeInTheDocument();
 	});
 

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -8,6 +8,8 @@ import {
 } from 'preact/hooks';
 
 import { nodeHasAncestor } from '../../util/nodeHasAncestor';
+import { KeyboardShortcutName, useKeyboardShortcut } from 'registers/keyboard-shortcuts';
+
 import { Markdown } from './Markdown';
 
 interface NoteProps {
@@ -90,6 +92,18 @@ export function Note(props: NoteProps): JSX.Element {
 	]);
 
 	/**
+	 * Leave editing mode if event was received from textarea element.
+	 */
+	const leaveEditingModeFromTextarea = useCallback((e: KeyboardEvent) => {
+		if (e.target === textareaRef.current) {
+			leaveEditingMode();
+		}
+	}, [leaveEditingMode]);
+
+	// Leave editing on keyboard shortcut
+	useKeyboardShortcut(KeyboardShortcutName.EDITING_FINISH, leaveEditingModeFromTextarea);
+
+	/**
 	 * Enter edit mode on click, unless the user was selecting
 	 * text and included text outside the note.
 	 */
@@ -148,14 +162,6 @@ export function Note(props: NoteProps): JSX.Element {
 			textarea.addEventListener(
 				'keydown',
 				(e) => {
-					// Leave editing mode on Ctrl + Enter or Escape
-					if (
-						(e.key === 'Enter' && e.ctrlKey) ||
-						e.key === 'Escape'
-					) {
-						leaveEditingMode();
-					}
-
 					// Insert a tab character on tab press
 					if (e.key === 'Tab') {
 						e.preventDefault();

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -94,8 +94,8 @@ export function Note(props: NoteProps): JSX.Element {
 	/**
 	 * Leave editing mode if event was received from textarea element.
 	 */
-	const leaveEditingModeFromTextarea = useCallback((e: KeyboardEvent) => {
-		if (e.target === textareaRef.current) {
+	const leaveEditingModeFromTextarea = useCallback(() => {
+		if (document.activeElement === textareaRef.current) {
 			leaveEditingMode();
 		}
 	}, [leaveEditingMode]);

--- a/app/assets/js/src/registers/keyboard-shortcuts/keyboardShortcutsRegister.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/keyboardShortcutsRegister.ts
@@ -75,8 +75,13 @@ document.addEventListener('keydown', (e) => {
 		activeElement instanceof HTMLTextAreaElement ||
 		(activeElement instanceof HTMLElement && activeElement.isContentEditable)
 	) {
-		// ...unless the Ctrl / Cmd modifier key is also pressed, ignore the event
-		if (!(e.ctrlKey || e.metaKey)) {
+		// ...unless the Ctrl / Cmd modifier key is also pressed,
+		// or the key is recognised as a special case, ignore the event
+		if (!(
+			e.ctrlKey ||
+			e.metaKey ||
+			e.key === 'Escape'
+		)) {
 			return;
 		}
 	}

--- a/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.test.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.test.ts
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 
 import { KeyboardShortcutName } from '../types/KeyboardShortcutName';
 import { registerKeyboardShortcut } from '../registerKeyboardShortcut';
+import { getKeyboardShortcut } from '../getKeyboardShortcut';
 
 import { addKeyboardShortcutListener, removeKeyboardShortcutListener } from './addKeyboardShortcutListener';
 
@@ -18,13 +19,31 @@ beforeAll(() => {
 });
 
 describe('addKeyboardShortcutListener', () => {
-	test('throws an error if called with an unregistered keyboard shortcut', () => {
+	test('can be called before a keyboard shortcut is registered', async () => {
+		const user = userEvent.setup();
+
+		const shortcutName = 'Test keyboard shortcut';
+		const spy = jest.fn();
+
 		expect(
 			() => addKeyboardShortcutListener(
-				'Unregistered keyboard shortcut' as KeyboardShortcutName,
-				() => {}
+				shortcutName,
+				spy
 			)
-		).toThrow();
+		).not.toThrow();
+
+		const keyboardShortcut = getKeyboardShortcut(shortcutName);
+		expect(keyboardShortcut).toEqual({
+			name: shortcutName,
+			shortcuts: [],
+			listeners: [spy],
+		});
+
+		registerKeyboardShortcut(shortcutName, [{ key: 'f' }]);
+
+		expect(spy).not.toHaveBeenCalled();
+		await user.keyboard('f');
+		expect(spy).toHaveBeenCalled();
 	});
 
 	test('adds a listener to a keyboard shortcut', async () => {

--- a/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.ts
@@ -1,5 +1,8 @@
 import { KeyboardShortcutName } from '../types/KeyboardShortcutName';
+import type { KeyboardShortcutInfo } from '../types';
+
 import { keyboardShortcutsRegister } from '../keyboardShortcutsRegister';
+import { registerKeyboardShortcut } from '../registerKeyboardShortcut';
 
 interface AddKeyboardShortcutListenerOptions {
 	/**
@@ -21,15 +24,18 @@ export function addKeyboardShortcutListener(
 	listener: () => void,
 	options?: AddKeyboardShortcutListenerOptions,
 ): void {
-	const shortcutInfo = keyboardShortcutsRegister.get(name);
-
-	if (!shortcutInfo) {
-		throw new Error(`Cannot add listener to unregistered keyboard shortcut "${name}"`);
-	}
-
 	if (options?.signal?.aborted) {
 		return;
 	}
+
+	const shortcutInfo: KeyboardShortcutInfo = (() => {
+		const shortcutInfo = keyboardShortcutsRegister.get(name);
+		if (shortcutInfo) {
+			return shortcutInfo;
+		}
+
+		return registerKeyboardShortcut(name, []);
+	})();
 
 	if (shortcutInfo.listeners.includes(listener)) {
 		// Behave like `addEventListener` - don't bind the same listener twice

--- a/app/assets/js/src/registers/keyboard-shortcuts/registerKeyboardShortcut.test.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/registerKeyboardShortcut.test.ts
@@ -59,6 +59,16 @@ describe('registerKeyboardShortcut', () => {
 		controller.abort();
 	});
 
+	test('returns the registered information', () => {
+		expect(
+			registerKeyboardShortcut('Test', [{ key: 'a', alt: true }])
+		).toEqual({
+			name: 'Test',
+			shortcuts: [{ key: 'a', alt: true }],
+			listeners: [],
+		});
+	});
+
 	test('can be called again to override existing keyboard shortcuts', async () => {
 		const user = userEvent.setup();
 
@@ -84,5 +94,69 @@ describe('registerKeyboardShortcut', () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 
 		controller.abort();
+	});
+
+	test('does not fire when keys are pressed without Ctrl while focus is in a form element', async () => {
+		const user = userEvent.setup();
+
+		const inputEl = document.createElement('input');
+		inputEl.type = 'text';
+		document.body.append(inputEl);
+
+		const selectEl = document.createElement('select');
+		document.body.append(selectEl);
+
+		const textareaEl = document.createElement('textarea');
+		document.body.append(textareaEl);
+
+		// TODO: Elements that are contentEditable should also behave this way,
+		// but jsdom doesn't support contentEditable
+		// https://github.com/jsdom/jsdom/issues/1670
+
+		registerKeyboardShortcut('Test shortcut', [
+			// Character without Ctrl
+			{ key: 'a' },
+			// Character with Ctrl
+			{ key: 'b', ctrl: true },
+			// Special case
+			{ key: 'Escape' },
+		]);
+
+		const spy = jest.fn();
+		addKeyboardShortcutListener('Test shortcut', spy);
+		expect(spy).toHaveBeenCalledTimes(0);
+
+		// All shortcuts work with focus on the body
+		await user.keyboard('a');
+		expect(spy).toHaveBeenCalledTimes(1);
+		await user.keyboard('{Control>}b{/Control}');
+		expect(spy).toHaveBeenCalledTimes(2);
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(3);
+
+		// Character without Ctrl doesn't work when focus is in editable elements
+		await user.click(inputEl);
+		await user.keyboard('a');
+		expect(spy).toHaveBeenCalledTimes(3);
+		await user.keyboard('{Control>}b{/Control}');
+		expect(spy).toHaveBeenCalledTimes(4);
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(5);
+
+		await user.click(selectEl);
+		await user.keyboard('a');
+		expect(spy).toHaveBeenCalledTimes(5);
+		await user.keyboard('{Control>}b{/Control}');
+		expect(spy).toHaveBeenCalledTimes(6);
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(7);
+
+		await user.click(textareaEl);
+		await user.keyboard('a');
+		expect(spy).toHaveBeenCalledTimes(7);
+		await user.keyboard('{Control>}b{/Control}');
+		expect(spy).toHaveBeenCalledTimes(8);
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(9);
 	});
 });

--- a/app/assets/js/src/registers/keyboard-shortcuts/registerKeyboardShortcut.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/registerKeyboardShortcut.ts
@@ -14,7 +14,7 @@ export const newKeyboardShortcutRegisteredListeners: Array<NewKeyboardShortcutRe
  *
  * A keyboard shortcut can be re-registered to override its shortcuts.
  */
-export function registerKeyboardShortcut(name: KeyboardShortcutName, shortcuts: Array<KeyCombo>): void {
+export function registerKeyboardShortcut(name: KeyboardShortcutName, shortcuts: Array<KeyCombo>): KeyboardShortcutInfo {
 	const listeners = keyboardShortcutsRegister.get(name)?.listeners ?? [];
 
 	const info = {
@@ -27,4 +27,6 @@ export function registerKeyboardShortcut(name: KeyboardShortcutName, shortcuts: 
 	for (const listener of newKeyboardShortcutRegisteredListeners) {
 		listener(info);
 	}
+
+	return info;
 }

--- a/app/assets/js/src/registers/keyboard-shortcuts/types/KeyboardShortcutName.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/types/KeyboardShortcutName.ts
@@ -6,6 +6,8 @@ export const KeyboardShortcutName = {
 	DATA_SAVE: 'Save data',
 
 	KEYBOARD_SHORTCUTS_MODAL_OPEN: 'Open keyboard shortcuts modal',
+
+	EDITING_FINISH: 'Finish editing',
 } as const;
 // Allow any string
 /* eslint-disable-next-line @typescript-eslint/ban-types */


### PR DESCRIPTION
Resolves #26 

This PR reworks the keyboard shortcuts register code so that a shortcut can have listeners bound to it before it is registered. This causes it to be registered without any key combos, and allows those key combos to be defined later or not at all. This approach works much better for testing, and may have other benefits later, but at the moment it also means shortcuts with an empty `shortcuts` array should be treated as though they were not registered.

This refactor has then allowed for the `<Note>` component to rely on a new keyboard shortcut to leave its editing mode, instead of hard-coding the "Ctrl + Enter" and "Escape" keyboard shortcuts within the component. Because this new shortcut is registered, it has the added benefit of appearing in the keyboard shortcuts modal.

This PR also adds some tests that had been missing, such as for some keyboard shortcuts to not fire while keyboard focus is in certain elements such as `<input>`. "Escape" has been added as a special case that can fire keyboard shortcuts in this context without requiring `Control` to be pressed.