### PR TITLE
Added condition to `useKeyboardShortcut`, and improved `preventDefault` behaviour

### DIFF
--- a/app/assets/js/src/components/KeyboardShortcutsModal.tsx
+++ b/app/assets/js/src/components/KeyboardShortcutsModal.tsx
@@ -23,7 +23,8 @@ export function KeyboardShortcutModal(): JSX.Element {
 	const [open, setOpen] = useState(false);
 	useKeyboardShortcut(
 		KeyboardShortcutName.KEYBOARD_SHORTCUTS_MODAL_OPEN,
-		() => setOpen(true)
+		() => setOpen(true),
+		!open
 	);
 
 	const keyboardShortcutsInfo = useKeyboardShortcuts();

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -126,7 +126,11 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 		() => setCommandPaletteOpen(false),
 		[]
 	);
-	useKeyboardShortcut(KeyboardShortcutName.COMMAND_PALETTE_OPEN, openCommandPalette);
+	useKeyboardShortcut(
+		KeyboardShortcutName.COMMAND_PALETTE_OPEN,
+		openCommandPalette,
+		!commandPaletteOpen
+	);
 
 	/**
 	 * Save all day and task data, while giving the user feedback.

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -101,7 +101,11 @@ export function Note(props: NoteProps): JSX.Element {
 	}, [leaveEditingMode]);
 
 	// Leave editing on keyboard shortcut
-	useKeyboardShortcut(KeyboardShortcutName.EDITING_FINISH, leaveEditingModeFromTextarea);
+	useKeyboardShortcut(
+		KeyboardShortcutName.EDITING_FINISH,
+		leaveEditingModeFromTextarea,
+		isEditing
+	);
 
 	/**
 	 * Enter edit mode on click, unless the user was selecting

--- a/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.test.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.test.ts
@@ -76,4 +76,60 @@ describe('useKeyboardShortcut', () => {
 
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
+
+	describe('if the condition is false', () => {
+		test('doesn\'t bind a keyboard shortcut to a listener', async () => {
+			const user = userEvent.setup();
+			const spy = jest.fn();
+
+			const { rerender } = renderHook(
+				(condition) => useKeyboardShortcut(
+					KeyboardShortcutName.DATA_SAVE,
+					spy,
+					condition
+				),
+				{ initialProps: true }
+			);
+
+			expect(spy).not.toHaveBeenCalled();
+
+			await user.keyboard('a');
+
+			expect(spy).toHaveBeenCalledTimes(1);
+
+			rerender(false);
+
+			await user.keyboard('a');
+
+			expect(spy).toHaveBeenCalledTimes(1);
+		});
+
+		test('doesn\'t bind a keyboard shortcut to a command', async () => {
+			const user = userEvent.setup();
+			const spy = jest.fn();
+
+			addCommandListener('__TEST_COMMAND_A__', spy);
+
+			const { rerender } = renderHook(
+				(condition) => useKeyboardShortcut(
+					KeyboardShortcutName.DATA_SAVE,
+					'__TEST_COMMAND_A__',
+					condition
+				),
+				{ initialProps: true }
+			);
+
+			expect(spy).not.toHaveBeenCalled();
+
+			await user.keyboard('a');
+
+			expect(spy).toHaveBeenCalledTimes(1);
+
+			rerender(false);
+
+			await user.keyboard('a');
+
+			expect(spy).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
@@ -15,18 +15,23 @@ import { bindKeyboardShortcutToCommand } from '../listeners/bindKeyboardShortcut
 /**
  * Bind a callback to a keyboard shortcut, within a Preact component.
  */
-export function useKeyboardShortcut(name: KeyboardShortcutName, listener: () => void): void;
+export function useKeyboardShortcut(name: KeyboardShortcutName, listener: () => void, condition?: boolean): void;
 /**
  * Bind a keyboard shortcut to fire a command, within a Preact component.
  *
  * For binding callbacks to commands, see {@linkcode useCommand}
  */
-export function useKeyboardShortcut(name: KeyboardShortcutName, command: CommandId): void;
+export function useKeyboardShortcut(name: KeyboardShortcutName, command: CommandId, condition?: boolean): void;
 export function useKeyboardShortcut(
 	name: KeyboardShortcutName,
 	listenerOrCommand: (() => void) | CommandId,
+	condition?: boolean
 ): void {
 	useEffect(() => {
+		if (condition === false) {
+			return;
+		}
+
 		const controller = new AbortController();
 		const { signal } = controller;
 
@@ -37,5 +42,5 @@ export function useKeyboardShortcut(
 		}
 
 		return () => controller.abort();
-	}, [name, listenerOrCommand]);
+	}, [condition, name, listenerOrCommand]);
 }

--- a/app/assets/js/src/registers/keyboard-shortcuts/keyboardShortcutsRegister.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/keyboardShortcutsRegister.ts
@@ -90,14 +90,20 @@ document.addEventListener('keydown', (e) => {
 	const shortcuts = Array.from(keyboardShortcutsRegister.values());
 	const matchingShortcuts = shortcuts.filter((item) => keyboardShortcutWasPressed(item, e));
 
-	if (matchingShortcuts.length > 0) {
+	const matchingShortcutListeners = matchingShortcuts.flatMap(({ listeners }) => listeners);
+
+	const hasListeners = matchingShortcutListeners.length > 0;
+	const isEscape = e.key === 'Escape';
+	// The escape key is hooked up to important accessibility features,
+	// so its default action shouldn't be prevented
+	const shouldPreventDefault = hasListeners && !isEscape;
+
+	if (shouldPreventDefault) {
 		e.preventDefault();
 	}
 
 	// Fire all listeners for pressed shortcuts
-	for (const shortcut of matchingShortcuts) {
-		for (const listener of shortcut.listeners) {
-			listener();
-		}
+	for (const listener of matchingShortcutListeners) {
+		listener();
 	}
 });


### PR DESCRIPTION
In attempts to use Chrome 120's new `CloseWatcher` API, I found that the current use of `useKeyboardShortcut` is leading to the default action of the "Escape" key being prevented.

This PR adds a condition argument to `useKeyboardShortcut` to limit when listeners are bound, and improves the `preventDefault` handling of the keyboard shortcuts register so that the default action is not prevented if no listeners are bound to a keyboard shortcut. Additionally, the default action of the "Escape" key is no longer ever prevented.