### PR TITLE
Use the `CloseWatcher` API as a progressive enhancement

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -452,10 +452,10 @@ module.exports = {
 		'@stylistic/jsx-tag-spacing': [
 			'error',
 			{
-				"closingSlash": "never",
-				"beforeSelfClosing": "always",
-				"afterOpening": "never",
-				"beforeClosing": "allow"
+				'closingSlash': 'never',
+				'beforeSelfClosing': 'always',
+				'afterOpening': 'never',
+				'beforeClosing': 'allow'
 			},
 		],
 	},
@@ -465,6 +465,6 @@ module.exports = {
 			files: ['*.{spec,test}.{j,t}{s,sx}'],
 			plugins: ['jest'],
 			extends: ['plugin:jest/recommended'],
-		}
+		},
 	],
 };

--- a/app/assets/js/src/components/shared/Modal.tsx
+++ b/app/assets/js/src/components/shared/Modal.tsx
@@ -1,7 +1,11 @@
 import { h, type ComponentChildren, type JSX } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
-import { classNames, useBlurCallback } from 'util/index';
+import {
+	classNames,
+	useBlurCallback,
+	useCloseWatcher,
+} from 'util/index';
 
 import { getDeepActiveElement } from '../../util';
 
@@ -80,21 +84,7 @@ export function Modal(props: ModalProps): JSX.Element {
 	}, [open, onOpen]);
 
 	// Handle closing on Escape
-	useEffect(() => {
-		if (!open) {
-			return;
-		}
-
-		const controller = new AbortController();
-		const { signal } = controller;
-
-		// Close on Escape key
-		document.addEventListener('keydown', (e) => {
-			if (e.key === 'Escape') {
-				onClose();
-			}
-		}, { signal });
-	}, [open, onClose]);
+	useCloseWatcher(onClose, open);
 
 	// Handle closing on blur
 	useBlurCallback(modalRef, onClose, open);

--- a/app/assets/js/src/dom-lib/CloseWatcher.d.ts
+++ b/app/assets/js/src/dom-lib/CloseWatcher.d.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, no-var */
+
+interface CloseWatcherOptions {
+	signal?: AbortSignal;
+}
+
+interface CloseWatcher extends EventTarget {
+	requestClose(): void;
+	close(): void;
+	destroy(): void;
+
+	oncancel: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+	onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+}
+
+declare global {
+	interface Window {
+		/**
+		 * [HTML Specification](https://html.spec.whatwg.org/multipage/interaction.html#the-closewatcher-interface)
+		 */
+		CloseWatcher?:  {
+			prototype: CloseWatcher;
+			new(options?: CloseWatcherOptions): CloseWatcher;
+		};
+	}
+}
+
+export {};

--- a/app/assets/js/src/dom-lib/CloseWatcher.d.ts
+++ b/app/assets/js/src/dom-lib/CloseWatcher.d.ts
@@ -1,19 +1,24 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, no-var */
-
 interface CloseWatcherOptions {
+	/**
+	 * If the `signal` option is provided, then *watcher* can be destroyed (as if by `watcher.destroy()`) by aborting the given `AbortSignal`.
+	 */
 	signal?: AbortSignal;
 }
 
-interface CloseWatcher extends EventTarget {
-	requestClose(): void;
-	close(): void;
-	destroy(): void;
-
-	oncancel: ((this: GlobalEventHandlers, ev: Event) => any) | null;
-	onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
-}
-
 declare global {
+	interface CloseWatcher extends EventTarget {
+		requestClose(): void;
+		close(): void;
+		destroy(): void;
+
+		// Following the pattern from built-in TypeScript
+		// DOM API types, which use explicit `any`
+		/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+		oncancel: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+		/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+		onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
+	}
+
 	interface Window {
 		/**
 		 * [HTML Specification](https://html.spec.whatwg.org/multipage/interaction.html#the-closewatcher-interface)

--- a/app/assets/js/src/util/index.ts
+++ b/app/assets/js/src/util/index.ts
@@ -11,6 +11,7 @@ export { useAsyncData } from './useAsyncData';
 export type { AsyncDataState } from './useAsyncData';
 export { useBlurCallback } from './useBlurCallback';
 export { useViewTransition } from './useViewTransition';
+export { useCloseWatcher } from './useCloseWatcher';
 
 export { CSSKeyframes } from './CSSKeyframes';
 

--- a/app/assets/js/src/util/useCloseWatcher.test.ts
+++ b/app/assets/js/src/util/useCloseWatcher.test.ts
@@ -1,0 +1,42 @@
+import {
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
+
+import { renderHook } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+
+import { useCloseWatcher } from './useCloseWatcher';
+
+describe('useCloseWatcher', () => {
+	test('binds a callback to be fired when "Escape" is pressed', async () => {
+		const user = userEvent.setup();
+		const spy = jest.fn();
+
+		renderHook(() => useCloseWatcher(spy));
+		expect(spy).not.toHaveBeenCalled();
+
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test('if the condition is false, doesn\'t bind a callback', async () => {
+		const user = userEvent.setup();
+		const spy = jest.fn();
+
+		const { rerender } = renderHook(
+			(condition) => useCloseWatcher(spy, condition),
+			{ initialProps: false }
+		);
+		expect(spy).not.toHaveBeenCalled();
+
+		await user.keyboard('{Escape}');
+		expect(spy).not.toHaveBeenCalled();
+
+		rerender(true);
+		await user.keyboard('{Escape}');
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/assets/js/src/util/useCloseWatcher.test.ts
+++ b/app/assets/js/src/util/useCloseWatcher.test.ts
@@ -15,7 +15,7 @@ describe('useCloseWatcher', () => {
 		const user = userEvent.setup();
 		const spy = jest.fn();
 
-		renderHook(() => useCloseWatcher(spy));
+		renderHook(() => useCloseWatcher(spy, true));
 		expect(spy).not.toHaveBeenCalled();
 
 		await user.keyboard('{Escape}');

--- a/app/assets/js/src/util/useCloseWatcher.ts
+++ b/app/assets/js/src/util/useCloseWatcher.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'preact/hooks';
+
+export function useCloseWatcher(callback: () => void, condition?: boolean): void {
+	useEffect(() => {
+		if (condition === false) {
+			return;
+		}
+
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		if (window.CloseWatcher) {
+			const watcher = new window.CloseWatcher({ signal });
+			watcher.addEventListener('close', () => callback());
+		} else {
+			document.addEventListener(
+				'keydown',
+				(e) => {
+					if (e.key === 'Escape') {
+						callback();
+					}
+				},
+				{ signal }
+			);
+		}
+
+		return () => {
+			controller.abort();
+		};
+	}, [condition, callback]);
+
+	document.createElement('div').onclick;
+}

--- a/app/assets/js/src/util/useCloseWatcher.ts
+++ b/app/assets/js/src/util/useCloseWatcher.ts
@@ -1,6 +1,15 @@
 import { useEffect } from 'preact/hooks';
 
-export function useCloseWatcher(callback: () => void, condition?: boolean): void {
+/**
+ * Configure a callback to be called when a UI component should be closed.
+ * If supported, this will use the
+ * [`CloseWatcher`](https://html.spec.whatwg.org/multipage/interaction.html#the-closewatcher-interface)
+ * API. Otherwise, an event listener will be set up for the "Escape" key.
+ *
+ * @param callback The function that should be called to close the UI component.
+ * @param condition Whether or not the UI component is currently open.
+ */
+export function useCloseWatcher(callback: () => void, condition: boolean): void {
 	useEffect(() => {
 		if (condition === false) {
 			return;

--- a/app/assets/js/src/util/useCloseWatcher.ts
+++ b/app/assets/js/src/util/useCloseWatcher.ts
@@ -28,6 +28,4 @@ export function useCloseWatcher(callback: () => void, condition?: boolean): void
 			controller.abort();
 		};
 	}, [condition, callback]);
-
-	document.createElement('div').onclick;
 }


### PR DESCRIPTION
Chrome 120 shipped the new [`CloseWatcher` API](https://developer.chrome.com/blog/new-in-chrome-120/#close-watcher), which allows UI close events to be set up more accessibly by relying on the browser to determine which interactions should trigger close events. For example, the "back" button on Android devices.

This PR implements a new `useCloseWatcher` hook, which uses the `CloseWatcher` API as a progressive enhancement. In browsers that don't support it, it falls back on using a keydown event listener that listens for the "Escape" key being pressed. It also updates the `Modal` component to use this new hook.