### PR TITLE
Task notes

### DIFF
--- a/app/assets/js/src/components/TaskDetail.test.tsx
+++ b/app/assets/js/src/components/TaskDetail.test.tsx
@@ -1,0 +1,31 @@
+import { h } from 'preact';
+
+import {
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+
+import { render } from '@testing-library/preact';
+import '@testing-library/jest-dom/jest-globals';
+
+import { clear, createTask } from 'data';
+
+import { TaskDetail } from './TaskDetail';
+
+describe('TaskDetail', () => {
+	beforeEach(() => {
+		clear();
+	});
+
+	test('renders the task\'s note', () => {
+		const taskId = createTask({
+			note: 'Task note',
+		});
+
+		const { getByText } = render(<TaskDetail taskId={taskId} />);
+
+		expect(getByText('Task note')).toBeInTheDocument();
+	});
+});

--- a/app/assets/js/src/components/TaskDetail.tsx
+++ b/app/assets/js/src/components/TaskDetail.tsx
@@ -1,10 +1,15 @@
 import { h, type JSX } from 'preact';
+import { useCallback } from 'preact/hooks';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
-import { useTaskInfo } from 'data/tasks';
-import { setDayTaskInfo, useAllDayTaskInfo } from 'data/dayTasks';
+import {
+	setDayTaskInfo,
+	setTaskInfo,
+	useAllDayTaskInfo,
+	useTaskInfo,
+} from 'data';
 
 import { Note } from './shared/Note';
 import { Markdown } from './shared/Markdown';
@@ -26,6 +31,15 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 	const taskInfo = useTaskInfo(taskId);
 	const dayTasksInfo = useAllDayTaskInfo({ taskId });
 
+	const setTaskNote = useCallback(
+		(note: string) => {
+			setTaskInfo(taskId, { note });
+		},
+		[taskId]
+	);
+
+	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
+
 	if (!taskInfo) {
 		return null;
 	}
@@ -34,6 +48,12 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 		<Markdown
 			content={`<h2 class="orange-twist__title">${taskInfo.name}</h2>`}
 			inline
+		/>
+		<Note
+			class="task-detail__note"
+			note={taskInfo.note}
+			onNoteChange={setTaskNote}
+			saveChanges={saveChanges}
 		/>
 		{dayTasksInfo.map(({ dayName, taskId, note }, i, arr) => (
 			<details

--- a/app/assets/js/src/components/shared/Note.test.tsx
+++ b/app/assets/js/src/components/shared/Note.test.tsx
@@ -63,6 +63,18 @@ describe('Note', () => {
 		expect(queryByText(note)).toBeInTheDocument();
 	});
 
+	test('renders any specified CSS classes', () => {
+		render(<Note
+			note={'Test note'}
+			onNoteChange={() => {}}
+			saveChanges={() => {}}
+
+			class="test-class"
+		/>);
+
+		expect(document.querySelector('.test-class')).toBeInTheDocument();
+	});
+
 	test('enters edit mode when edit button is clicked', async () => {
 		const user = userEvent.setup();
 

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -7,8 +7,15 @@ import {
 	useState,
 } from 'preact/hooks';
 
-import { nodeHasAncestor, useBlurCallback } from 'util/index';
-import { KeyboardShortcutName, useKeyboardShortcut } from 'registers/keyboard-shortcuts';
+import {
+	classNames,
+	nodeHasAncestor,
+	useBlurCallback,
+} from 'util/index';
+import {
+	KeyboardShortcutName,
+	useKeyboardShortcut,
+} from 'registers/keyboard-shortcuts';
 
 import { Markdown } from './Markdown';
 
@@ -16,6 +23,8 @@ interface NoteProps {
 	note: string | null;
 	onNoteChange: (note: string) => void;
 	saveChanges: () => void;
+
+	class?: string;
 }
 
 /**
@@ -222,7 +231,7 @@ export function Note(props: NoteProps): JSX.Element {
 		}
 	}, [isEditing]);
 
-	return <div class="note">
+	return <div class={classNames('note', props.class)}>
 		{isEditing
 			? <div
 				class="note__edit-content"

--- a/app/assets/js/src/data/dayTasks/persistence/loadDayTasks.test.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/loadDayTasks.test.ts
@@ -131,4 +131,23 @@ describe('loadDayTasks', () => {
 			['2023-11-13_2', secondDayTaskInfo],
 		]);
 	});
+
+	test('can be passed serialised data as an argument', async () => {
+		await loadDayTasks(JSON.stringify([
+			['2023-12-10_1', {
+				dayName: '2023-12-10',
+				taskId: 1,
+				status: TaskStatus.IN_PROGRESS,
+				note: '',
+			}],
+		]));
+		expect(Array.from(dayTasksRegister.entries())).toEqual([
+			['2023-12-10_1', {
+				dayName: '2023-12-10',
+				taskId: 1,
+				status: TaskStatus.IN_PROGRESS,
+				note: '',
+			}],
+		]);
+	});
 });

--- a/app/assets/js/src/data/dayTasks/persistence/loadDayTasks.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/loadDayTasks.ts
@@ -30,12 +30,11 @@ export async function loadDayTasks(): Promise<void> {
 	const serialisedDayTasksInfo = localStorage.getItem('day-tasks');
 
 	if (!serialisedDayTasksInfo) {
+		dayTasksRegister.clear();
 		return;
 	}
 
 	const persistedDayTasksInfo = JSON.parse(serialisedDayTasksInfo) as unknown;
-
-	dayTasksRegister.clear();
 
 	if (!(
 		Array.isArray(persistedDayTasksInfo) &&
@@ -44,5 +43,6 @@ export async function loadDayTasks(): Promise<void> {
 		throw new Error(`Persisted day tasks data is invalid: ${serialisedDayTasksInfo}`);
 	}
 
+	dayTasksRegister.clear();
 	dayTasksRegister.set(persistedDayTasksInfo);
 }

--- a/app/assets/js/src/data/dayTasks/persistence/updateOldDayInfo.test.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/updateOldDayInfo.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { updateOldDayTaskInfo } from './updateOldDayTaskInfo';
+
+describe('updateOldDayTaskInfo', () => {
+	test('throws an error if passed unrecognised data', () => {
+		expect(() => {
+			updateOldDayTaskInfo('invalid data');
+		}).toThrow();
+	});
+});

--- a/app/assets/js/src/data/dayTasks/persistence/updateOldDayTaskInfo.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/updateOldDayTaskInfo.ts
@@ -73,6 +73,7 @@ export function updateOldDayTaskInfo(val: unknown): DayTaskInfo {
 	// update the data to the next version
 	if (oldDayTaskInfoVersion === 1) {
 		// No migration currently needed
+		newVal = oldVal;
 	} else {
 		assertAllUnionMembersHandled(oldDayTaskInfoVersion);
 	}

--- a/app/assets/js/src/data/dayTasks/setDayTaskInfo.test.ts
+++ b/app/assets/js/src/data/dayTasks/setDayTaskInfo.test.ts
@@ -45,6 +45,7 @@ describe('setDayTaskInfo', () => {
 			id: 1,
 			name: 'New task',
 			status: TaskStatus.IN_PROGRESS,
+			note: '',
 		});
 
 		expect(getDayInfo('2023-11-12')).toEqual({

--- a/app/assets/js/src/data/days/persistence/loadDays.test.ts
+++ b/app/assets/js/src/data/days/persistence/loadDays.test.ts
@@ -113,4 +113,21 @@ describe('loadDays', () => {
 			['2023-11-10', { name: '2023-11-10', ...tenthDayInfo }],
 		]);
 	});
+
+	test('can be passed serialised data as an argument', async () => {
+		await loadDays(JSON.stringify([
+			['2023-12-10', {
+				name: '2023-12-10',
+				note: '',
+				tasks: [],
+			}],
+		]));
+		expect(Array.from(daysRegister.entries())).toEqual([
+			['2023-12-10', {
+				name: '2023-12-10',
+				note: '',
+				tasks: [],
+			}],
+		]);
+	});
 });

--- a/app/assets/js/src/data/days/persistence/loadDays.ts
+++ b/app/assets/js/src/data/days/persistence/loadDays.ts
@@ -16,12 +16,11 @@ export async function loadDays(): Promise<void> {
 	const serialisedDaysInfo = localStorage.getItem('days');
 
 	if (!serialisedDaysInfo) {
+		daysRegister.clear();
 		return;
 	}
 
 	const persistedDaysInfo = JSON.parse(serialisedDaysInfo) as unknown;
-
-	daysRegister.clear();
 
 	if (!(
 		Array.isArray(persistedDaysInfo) &&
@@ -32,5 +31,6 @@ export async function loadDays(): Promise<void> {
 		throw new Error(`Persisted days data is invalid: ${serialisedDaysInfo}`);
 	}
 
+	daysRegister.clear();
 	daysRegister.set(persistedDaysInfo);
 }

--- a/app/assets/js/src/data/days/persistence/updateOldDayInfo.test.ts
+++ b/app/assets/js/src/data/days/persistence/updateOldDayInfo.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { updateOldDayInfo } from './updateOldDayInfo';
+
+describe('updateOldDayInfo', () => {
+	test('throws an error if passed unrecognised data', () => {
+		expect(() => {
+			updateOldDayInfo('invalid data');
+		}).toThrow();
+	});
+});

--- a/app/assets/js/src/data/days/persistence/updateOldDayInfo.ts
+++ b/app/assets/js/src/data/days/persistence/updateOldDayInfo.ts
@@ -70,6 +70,7 @@ export function updateOldDayInfo(val: unknown): DayInfo {
 	// update the data to the next version
 	if (oldDayInfoVersion === 1) {
 		// No migration currently needed
+		newVal = oldVal;
 	} else {
 		assertAllUnionMembersHandled(oldDayInfoVersion);
 	}

--- a/app/assets/js/src/data/days/persistence/updateOldDayInfo.ts
+++ b/app/assets/js/src/data/days/persistence/updateOldDayInfo.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+import { assertAllUnionMembersHandled } from 'util/index';
+import { isDayInfo, type DayInfo } from '../types/DayInfo';
+
+/**
+ * An array of tuples of schema version numbers and definitions,
+ * used to match old data against to determine how it needs to
+ * be updated.
+ */
+const oldDayInfoSchemas = [
+	[
+		1,
+		z.object({
+			name: z.string(),
+			note: z.string(),
+			tasks: z.array(z.number()).readonly(),
+		}).strict(),
+	],
+] as const satisfies ReadonlyArray<readonly [number, z.ZodType]>;
+
+/**
+ * Use an immediately indexed mapped function to construct a
+ * discriminated union of tuple types that can be used to
+ * return a linked version number and parsed value from
+ * {@linkcode getOldDayInfoSchemaVersion}.
+ */
+type GetOldDayInfoSchemaVersionResult = {
+	[K in keyof typeof oldDayInfoSchemas & number]: [
+		typeof oldDayInfoSchemas[K][0],
+		z.infer<typeof oldDayInfoSchemas[K][1]>
+	];
+}[keyof typeof oldDayInfoSchemas & number];
+
+/**
+ * Attempts to determine which old day schema version some
+ * unknown data matches. If a match is found, returns a tuple
+ * of the version number and parsed data.
+ *
+ * If no match is found, throws an error.
+ */
+function getOldDayInfoSchemaVersion(val: unknown): GetOldDayInfoSchemaVersionResult {
+	for (const [version, schema] of oldDayInfoSchemas) {
+		const parsedSchema = schema.safeParse(val);
+		if (parsedSchema.success) {
+			return [version, parsedSchema.data];
+		}
+	}
+
+	throw new Error('No valid old day info recognised');
+}
+
+/**
+ * Attempts to update unknown data to the latest version.
+ *
+ * If the data doesn't match a previous schema, throws an error.
+ */
+export function updateOldDayInfo(val: unknown): DayInfo {
+	// Once we've constructed valid day info, stop updating
+	if (isDayInfo(val)) {
+		return val;
+	}
+
+	const [oldDayInfoVersion, oldVal] = getOldDayInfoSchemaVersion(val);
+
+	let newVal: unknown;
+	// Based on the detected old schema version,
+	// update the data to the next version
+	// Based on the detected old schema version,
+	// update the data to the next version
+	if (oldDayInfoVersion === 1) {
+		// No migration currently needed
+	} else {
+		assertAllUnionMembersHandled(oldDayInfoVersion);
+	}
+
+	// Update recursively in case multiple migration steps are needed
+	return updateOldDayInfo(newVal);
+}

--- a/app/assets/js/src/data/tasks/createTask.test.ts
+++ b/app/assets/js/src/data/tasks/createTask.test.ts
@@ -40,6 +40,7 @@ describe('createTask', () => {
 			id: newId,
 			name: 'New task',
 			status: TaskStatus.TODO,
+			note: '',
 		});
 	});
 
@@ -52,17 +53,20 @@ describe('createTask', () => {
 			id: newIdPartial,
 			name: 'Custom task name',
 			status: TaskStatus.TODO,
+			note: '',
 		});
 
 		const newIdFull = createTask({
 			name: 'Custom task name',
 			status: TaskStatus.IN_PROGRESS,
+			note: 'Custom task note',
 		} satisfies Omit<TaskInfo, 'id'>);
 
 		expect(getTaskInfo(newIdFull)).toEqual({
 			id: newIdFull,
 			name: 'Custom task name',
 			status: TaskStatus.IN_PROGRESS,
+			note: 'Custom task note',
 		});
 	});
 

--- a/app/assets/js/src/data/tasks/getAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/getAllTaskInfo.test.ts
@@ -17,12 +17,14 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 2,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 describe('getAllTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/getTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/getTaskInfo.test.ts
@@ -17,12 +17,14 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 2,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 describe('getTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/hooks/useAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/hooks/useAllTaskInfo.test.ts
@@ -23,18 +23,21 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 2,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 const thirdTaskInfo: TaskInfo = {
 	id: 3,
 	name: 'Third task',
 	status: TaskStatus.COMPLETED,
+	note: 'Task note',
 };
 
 describe('useAllTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/hooks/useTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/hooks/useTaskInfo.test.ts
@@ -21,18 +21,21 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 2,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 const thirdTaskInfo: TaskInfo = {
 	id: 3,
 	name: 'Third task',
 	status: TaskStatus.COMPLETED,
+	note: 'Task note',
 };
 
 describe('useTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
@@ -18,12 +18,14 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 describe('loadTasks', () => {

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
@@ -45,8 +45,7 @@ describe('loadTasks', () => {
 
 		expect(Array.from(tasksRegister.entries())).toEqual([]);
 
-		const loadTasksResult = await loadTasksPromise;
-		expect(loadTasksResult).toBeUndefined();
+		await expect(loadTasksPromise).resolves.toBeUndefined();
 
 		expect(Array.from(tasksRegister.entries())).toEqual([
 			[1, firstTaskInfo],
@@ -64,8 +63,7 @@ describe('loadTasks', () => {
 
 		expect(Array.from(tasksRegister.entries())).toEqual([]);
 
-		const loadTasksResult = await loadTasksPromise;
-		expect(loadTasksResult).toBeUndefined();
+		await expect(loadTasksPromise).resolves.toBeUndefined();
 
 		expect(Array.from(tasksRegister.entries())).toEqual([]);
 	});
@@ -119,6 +117,25 @@ describe('loadTasks', () => {
 		expect(Array.from(tasksRegister.entries())).toEqual([
 			[1, firstTaskInfo],
 			[2, secondTaskInfo],
+		]);
+	});
+
+	test('can be passed serialised data as an argument', async () => {
+		await loadTasks(JSON.stringify([
+			[1, {
+				id: 1,
+				name: 'Task name',
+				status: TaskStatus.IN_PROGRESS,
+				note: '',
+			}],
+		]));
+		expect(Array.from(tasksRegister.entries())).toEqual([
+			[1, {
+				id: 1,
+				name: 'Task name',
+				status: TaskStatus.IN_PROGRESS,
+				note: '',
+			}],
 		]);
 	});
 });

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.ts
@@ -1,5 +1,4 @@
 import { tasksRegister } from '../tasksRegister';
-import { isTaskInfo, type TaskInfo } from '../types/TaskInfo';
 import { updateOldTaskInfo } from '../updateOldTaskInfo';
 
 /**
@@ -9,12 +8,14 @@ import { updateOldTaskInfo } from '../updateOldTaskInfo';
  * @returns A Promise which resolves when tasks info has finished loading,
  * or rejects when tasks info fails to load.
  */
-export async function loadTasks(): Promise<void> {
+export async function loadTasks(serialisedTasksInfo?: string): Promise<void> {
 	// Until we use an asynchronous API to store this data, emulate
 	// it by using the microtask queue.
 	await new Promise<void>((resolve) => queueMicrotask(resolve));
 
-	const serialisedTasksInfo = localStorage.getItem('tasks');
+	if (typeof serialisedTasksInfo === 'undefined') {
+		serialisedTasksInfo = localStorage.getItem('tasks') ?? undefined;
+	}
 
 	if (!serialisedTasksInfo) {
 		tasksRegister.clear();

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.ts
@@ -1,5 +1,6 @@
 import { tasksRegister } from '../tasksRegister';
 import { isTaskInfo, type TaskInfo } from '../types/TaskInfo';
+import { updateOldTaskInfo } from '../updateOldTaskInfo';
 
 /**
  * Asynchronously loads any persisted tasks info, overwriting any data
@@ -16,21 +17,27 @@ export async function loadTasks(): Promise<void> {
 	const serialisedTasksInfo = localStorage.getItem('tasks');
 
 	if (!serialisedTasksInfo) {
+		tasksRegister.clear();
 		return;
 	}
 
 	const persistedTasksInfo = JSON.parse(serialisedTasksInfo) as unknown;
 
-	tasksRegister.clear();
-
 	if (!(
 		Array.isArray(persistedTasksInfo) &&
-		persistedTasksInfo.every((el): el is [number, TaskInfo] => {
-			return Array.isArray(el) && typeof el[0] === 'number' && isTaskInfo(el[1]);
-		})
+		persistedTasksInfo.every((el): el is [number, unknown] => (
+			Array.isArray(el) &&
+			el.length === 2 &&
+			typeof el[0] === 'number'
+		))
 	)) {
 		throw new Error(`Persisted tasks data is invalid: ${serialisedTasksInfo}`);
 	}
 
-	tasksRegister.set(persistedTasksInfo);
+	const newTasksInfo = persistedTasksInfo.map(
+		([taskId, taskInfo]) => [taskId, updateOldTaskInfo(taskInfo)] as const
+	);
+
+	tasksRegister.clear();
+	tasksRegister.set(newTasksInfo);
 }

--- a/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
@@ -17,12 +17,14 @@ const firstTaskInfo: TaskInfo = {
 	id: 1,
 	name: 'First task',
 	status: TaskStatus.TODO,
+	note: '',
 };
 
 const secondTaskInfo: TaskInfo = {
 	id: 2,
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
+	note: 'Note',
 };
 
 describe('saveDays', () => {

--- a/app/assets/js/src/data/tasks/setTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.test.ts
@@ -30,6 +30,7 @@ describe('setTaskInfo', () => {
 			{
 				name: 'Task name',
 				status: TaskStatus.IN_PROGRESS,
+				note: 'Task note',
 			} satisfies Omit<TaskInfo, 'id'> // <- Ensure we're testing every option
 		);
 
@@ -37,6 +38,7 @@ describe('setTaskInfo', () => {
 			id: 1,
 			name: 'Task name',
 			status: TaskStatus.IN_PROGRESS,
+			note: 'Task note',
 		});
 	});
 
@@ -44,6 +46,7 @@ describe('setTaskInfo', () => {
 		setTaskInfo(1, {
 			name: 'Task name',
 			status: TaskStatus.TODO,
+			note: 'Task note',
 		} satisfies Omit<TaskInfo, 'id'>);
 
 		setTaskInfo(1, {
@@ -54,6 +57,7 @@ describe('setTaskInfo', () => {
 			id: 1,
 			name: 'Updated name',
 			status: TaskStatus.TODO,
+			note: 'Task note',
 		});
 	});
 

--- a/app/assets/js/src/data/tasks/setTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.ts
@@ -9,6 +9,7 @@ import { getDayTaskInfo, setDayTaskInfo } from 'data/dayTasks';
 const defaultTaskInfo = {
 	name: 'New task',
 	status: TaskStatus.TODO,
+	note: '',
 } as const satisfies Omit<TaskInfo, 'id'>;
 
 interface SetTaskInfoOptions {
@@ -49,6 +50,7 @@ export function setTaskInfo(
 
 		name: taskInfo.name ?? existingTaskInfo?.name ?? defaultTaskInfo.name,
 		status: taskInfo.status ?? existingTaskInfo?.status ?? defaultTaskInfo.status,
+		note: taskInfo.note ?? existingTaskInfo?.note ?? defaultTaskInfo.note,
 	});
 
 	if (consolidatedOptions.forCurrentDay && taskInfo.status) {

--- a/app/assets/js/src/data/tasks/types/TaskInfo.ts
+++ b/app/assets/js/src/data/tasks/types/TaskInfo.ts
@@ -7,6 +7,7 @@ export const taskInfoSchema = z.object({
 	id: z.number(),
 	name: z.string(),
 	status: z.nativeEnum(TaskStatus),
+	note: z.string(),
 });
 
 /**

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { TaskStatus } from 'types/TaskStatus';
+
+import { updateOldTaskInfo } from './updateOldTaskInfo';
+
+describe('updateOldTaskInfo', () => {
+	test('throws an error if passed unrecognised data', () => {
+		expect(() => {
+			updateOldTaskInfo('invalid data');
+		}).toThrow();
+	});
+
+	test('correctly migrates task data from schema version 1, adds an empty note', () => {
+		const result = updateOldTaskInfo({
+			id: 1,
+			name: 'Task name',
+			status: TaskStatus.IN_PROGRESS,
+		});
+
+		expect(result).toEqual({
+			id: 1,
+			name: 'Task name',
+			status: TaskStatus.IN_PROGRESS,
+			note: '',
+		});
+	});
+});

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import { assertAllUnionMembersHandled } from 'util/index';
+
+import type { TaskInfo } from './types';
+import { TaskStatus } from 'types/TaskStatus';
+import { isTaskInfo } from './types/TaskInfo';
+
+/**
+ * An array of tuples of schema version numbers and definitions,
+ * used to match old data against to determine how it needs to
+ * be updated.
+ */
+const oldTaskInfoSchemas = [
+	[
+		1,
+		z.object({
+			id: z.number(),
+			name: z.string(),
+			status: z.nativeEnum(TaskStatus),
+		}).strict(),
+	],
+] as const satisfies ReadonlyArray<readonly [number, z.ZodType]>;
+
+/**
+ * Use an immediately indexed mapped function to construct a
+ * discriminated union of tuple types that can be used to
+ * return a linked version number and parsed value from
+ * {@linkcode getOldTaskInfoSchemaVersion}.
+ */
+type GetOldTaskInfoSchemaVersionResult = {
+	[K in keyof typeof oldTaskInfoSchemas & number]: [
+		typeof oldTaskInfoSchemas[K][0],
+		z.infer<typeof oldTaskInfoSchemas[K][1]>
+	];
+}[keyof typeof oldTaskInfoSchemas & number];
+
+/**
+ * Attempts to determine which old task schema version some
+ * unknown data matches. If a match is found, returns a tuple
+ * of the version number and parsed data.
+ *
+ * If no match is found, throws an error.
+ */
+function getOldTaskInfoSchemaVersion(val: unknown): GetOldTaskInfoSchemaVersionResult {
+	for (const [version, schema] of oldTaskInfoSchemas) {
+		const parsedSchema = schema.safeParse(val);
+		if (parsedSchema.success) {
+			return [version, parsedSchema.data];
+		}
+	}
+
+	throw new Error('No valid old task info recognised');
+}
+
+/**
+ * Attempts to update unknown data to the latest version.
+ *
+ * If the data doesn't match a previous schema, throws an error.
+ */
+export function updateOldTaskInfo(val: unknown): TaskInfo {
+	// Once we've constructed valid task info, stop updating
+	if (isTaskInfo(val)) {
+		return val;
+	}
+
+	const [oldTaskInfoVersion, oldVal] = getOldTaskInfoSchemaVersion(val);
+
+	let newVal: unknown;
+	// Based on the detected old schema version,
+	// update the data to the next version
+	if (oldTaskInfoVersion === 1) {
+		newVal = {
+			...oldVal,
+			note: '',
+		};
+	} else {
+		assertAllUnionMembersHandled(oldTaskInfoVersion);
+	}
+
+	// Update recursively in case multiple migration steps are needed
+	return updateOldTaskInfo(newVal);
+}

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
@@ -84,6 +84,7 @@ export function updateOldTaskInfo(val: unknown): TaskInfo {
 		};
 	} else if (oldTaskInfoVersion === 2) {
 		// No migration currently needed
+		newVal = oldVal;
 	} else {
 		assertAllUnionMembersHandled(oldTaskInfoVersion);
 	}

--- a/app/assets/js/src/util/index.ts
+++ b/app/assets/js/src/util/index.ts
@@ -1,4 +1,5 @@
 export { animate } from './animate';
+export { assertAllUnionMembersHandled } from './assertAllUnionMembersHandled';
 export { classNames } from './classNames';
 export { escapeRegExpString } from './escapeRegExpString';
 export { getCurrentDateDayName } from './getCurrentDateDayName';

--- a/app/assets/scss/components/_task-detail.scss
+++ b/app/assets/scss/components/_task-detail.scss
@@ -1,0 +1,5 @@
+@use "../theme/spacing";
+
+.task-detail__note {
+	margin-top: spacing.$sm;
+}

--- a/app/assets/scss/main.scss
+++ b/app/assets/scss/main.scss
@@ -26,6 +26,7 @@
 	@include meta.load-css("components/note");
 	@include meta.load-css("components/orange-twist");
 	@include meta.load-css("components/task");
+	@include meta.load-css("components/task-detail");
 	@include meta.load-css("components/task-list");
 	@include meta.load-css("components/task-status");
 }


### PR DESCRIPTION
Resolves #8 

This PR adds a `note` field to tasks, which is displayed on the task detail page. It also implements a migration system to automatically update any old task info when it's loaded.

I've also added the skeleton of that migration system to the days and task days registers, though neither of them currently need any migrations. While I was in that area of the code, I've also updated all of the `loadAbc` functions to be able to accept a string of serialised data, which I anticipate will be useful when I eventually implement an import/export function and so need to be able to load data from a different source.