### PR TITLE
Unsaved changes warning

### DIFF
--- a/app/assets/js/src/components/shared/Note.test.tsx
+++ b/app/assets/js/src/components/shared/Note.test.tsx
@@ -34,7 +34,7 @@ describe('Note', () => {
 
 	test('renders edit button if no note', () => {
 		const {
-			queryByTitle,
+			getByRole,
 		} = render(
 			<Note
 				note={null}
@@ -43,7 +43,7 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note');
+		const editButton = getByRole('button', { name: 'Edit note' });
 		expect(editButton).toBeInTheDocument();
 	});
 
@@ -81,8 +81,7 @@ describe('Note', () => {
 		const note = 'Test note';
 
 		const {
-			queryByRole,
-			queryByTitle,
+			getByRole,
 		} = render(
 			<Note
 				note={note}
@@ -91,10 +90,10 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
-		const textarea = queryByRole('textbox') as HTMLTextAreaElement;
+		const textarea = getByRole('textbox') as HTMLTextAreaElement;
 
 		expect(textarea).toBeInTheDocument();
 		expect(textarea.value).toBe(note);
@@ -107,7 +106,7 @@ describe('Note', () => {
 
 		const {
 			queryByRole,
-			queryByText,
+			getByText,
 		} = render(
 			<Note
 				note={note}
@@ -116,8 +115,8 @@ describe('Note', () => {
 			/>
 		);
 
-		const noteContent = queryByText(note);
-		await user.click(noteContent!);
+		const noteContent = getByText(note);
+		await user.click(noteContent);
 
 		const textarea = queryByRole('textbox') as HTMLTextAreaElement;
 
@@ -132,8 +131,8 @@ describe('Note', () => {
 		const noteWithLink = 'This note has [a link](#)';
 
 		const {
+			getByRole,
 			queryByRole,
-			queryByTitle,
 		} = render(
 			<Note
 				note={noteWithLink}
@@ -142,16 +141,16 @@ describe('Note', () => {
 			/>
 		);
 
-		const linkInContent = queryByRole('link')!;
+		const linkInContent = getByRole('link');
 		expect(linkInContent).toBeInTheDocument();
 		await user.click(linkInContent);
 
 		expect(queryByRole('textbox')).not.toBeInTheDocument();
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
-		const textarea = queryByRole('textbox') as HTMLTextAreaElement;
+		const textarea = getByRole('textbox') as HTMLTextAreaElement;
 
 		expect(textarea).toBeInTheDocument();
 		expect(textarea.value).toBe(noteWithLink);
@@ -162,8 +161,7 @@ describe('Note', () => {
 		const spy = jest.fn();
 
 		const {
-			queryByRole,
-			queryByTitle,
+			getByRole,
 		} = render(
 			<Note
 				note={null}
@@ -172,10 +170,10 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
-		const textarea = queryByRole('textbox') as HTMLTextAreaElement;
+		const textarea = getByRole('textbox') as HTMLTextAreaElement;
 		await user.type(textarea, 'abcd');
 
 		expect(spy).toHaveBeenCalledWith('a');
@@ -196,8 +194,8 @@ describe('Note', () => {
 		);
 
 		const {
+			getByRole,
 			queryByRole,
-			queryByTitle,
 		} = render(
 			<Note
 				note={null}
@@ -206,7 +204,7 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 		expect(queryByRole('textbox')).toBeInTheDocument();
 
@@ -229,8 +227,8 @@ describe('Note', () => {
 		const user = userEvent.setup();
 
 		const {
+			getByRole,
 			queryByRole,
-			queryByTitle,
 		} = render(
 			<Note
 				note={null}
@@ -239,7 +237,7 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
 		expect(queryByRole('textbox')).toBeInTheDocument();
@@ -254,8 +252,7 @@ describe('Note', () => {
 		const spy = jest.fn();
 
 		const {
-			queryByRole,
-			queryByTitle,
+			getByRole,
 		} = render(
 			<Note
 				note={null}
@@ -264,9 +261,9 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
-		const textarea = queryByRole('textbox');
+		const textarea = getByRole('textbox');
 
 		expect(textarea).toHaveFocus();
 
@@ -282,8 +279,8 @@ describe('Note', () => {
 		const spy = jest.fn();
 
 		const {
+			getByRole,
 			queryByRole,
-			queryByTitle,
 		} = render(
 			<Note
 				note={null}
@@ -292,7 +289,7 @@ describe('Note', () => {
 			/>
 		);
 
-		const editButton = queryByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
 		expect(queryByRole('textbox')).toBeInTheDocument();
@@ -329,9 +326,9 @@ describe('Note', () => {
 			/>;
 		};
 
-		const { getByRole, getByTitle } = render(<NoteContainer />);
+		const { getByRole } = render(<NoteContainer />);
 
-		const editButton = getByTitle('Edit note')!;
+		const editButton = getByRole('button', { name: 'Edit note' });
 		await user.click(editButton);
 
 		const textarea = getByRole('textbox') as HTMLTextAreaElement;

--- a/app/assets/js/src/components/shared/Note.test.tsx
+++ b/app/assets/js/src/components/shared/Note.test.tsx
@@ -364,5 +364,28 @@ describe('Note', () => {
 			window.dispatchEvent(event);
 			expect(event.defaultPrevented).toBe(true);
 		});
+
+		test('if there are no unsaved changes, does not cancel the event', async () => {
+			const user = userEvent.setup();
+
+			const note = 'Test note';
+
+			const {
+				getByRole,
+			} = render(
+				<Note
+					note={note}
+					onNoteChange={() => {}}
+					saveChanges={() => {}}
+				/>
+			);
+
+			const editButton = getByRole('button', { name: 'Edit note' });
+			await user.click(editButton);
+
+			const event = new Event('beforeunload', { cancelable: true });
+			window.dispatchEvent(event);
+			expect(event.defaultPrevented).toBe(false);
+		});
 	});
 });

--- a/app/assets/js/src/components/shared/Note.test.tsx
+++ b/app/assets/js/src/components/shared/Note.test.tsx
@@ -342,4 +342,30 @@ describe('Note', () => {
 		expect(spy).toHaveBeenCalledWith('cab');
 		expect(spy).toHaveBeenCalledWith('cdab');
 	});
+
+	describe('if the tab is unloaded while in editing mode', () => {
+		test('if there are unsaved changes, cancels the event', async () => {
+			const user = userEvent.setup();
+
+			const note = 'Test note';
+
+			const {
+				getByRole,
+			} = render(
+				<Note
+					note={note}
+					onNoteChange={() => {}}
+					saveChanges={() => {}}
+				/>
+			);
+
+			const editButton = getByRole('button', { name: 'Edit note' });
+			await user.click(editButton);
+			await user.keyboard('abcd');
+
+			const event = new Event('beforeunload', { cancelable: true });
+			window.dispatchEvent(event);
+			expect(event.defaultPrevented).toBe(true);
+		});
+	});
 });

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -199,6 +199,26 @@ export function Note(props: NoteProps): JSX.Element {
 		};
 	}, [isEditing, leaveEditingMode]);
 
+	// Prompt the user about losing unsaved changes if the tab is closed in edit mode
+	useEffect(() => {
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		if (isEditing) {
+			window.addEventListener(
+				'beforeunload',
+				(e) => {
+					if (dirtyFlag.current) {
+						e.preventDefault();
+					}
+				},
+				{ signal }
+			);
+		}
+
+		return () => controller.abort();
+	}, [isEditing]);
+
 	// Leave editing mode when losing focus, but not when the tab loses focus
 	useBlurCallback(
 		textareaRef,

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -278,7 +278,9 @@ export function Note(props: NoteProps): JSX.Element {
 					class="note__edit"
 					title="Edit note"
 					onClick={() => setIsEditing(true)}
-				>✏️</button>
+				>
+					<span aria-hidden>✏️</span>
+				</button>
 			</div>
 		}
 	</div>;


### PR DESCRIPTION
Resolves #38 

It's possible to unload a page while a `<Note>` component is in editing mode, and lose unsaved changes. This PR adds a `beforeunload` event listener which cancels the action if there are unsaved changes, prompting the user to confirm they are happy to discard them before unloading the page.

It also makes a minor improvement to the accessibility of the edit button, that I noticed while writing my tests.