### PR TITLE
Fix display of task names on detail pages

### DIFF
--- a/app/assets/js/src/components/TaskDetail.tsx
+++ b/app/assets/js/src/components/TaskDetail.tsx
@@ -46,7 +46,7 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 
 	return <section class="orange-twist__section">
 		<Markdown
-			content={`<h2 class="orange-twist__title">${taskInfo.name}</h2>`}
+			content={`## ${taskInfo.name}`}
 			inline
 		/>
 		<Note

--- a/app/assets/scss/components/_content.scss
+++ b/app/assets/scss/components/_content.scss
@@ -6,6 +6,14 @@
 .content {
 	@include typography.base-body;
 
+	h1 {
+		@include typography.heading-1;
+	}
+
+	h2 {
+		@include typography.heading-2;
+	}
+
 	a {
 		@include palette.link;
 	}


### PR DESCRIPTION
Resolves #39 

Using HTML in Markdown to make the task name display as an `<h2>` on task detail pages causes any Markdown formatting within the name (such as links or code blocks) to be displayed as raw text.

I had been using HTML syntax to apply a class name in order to use a particular font size. But instead now I've just applied that to `<h2>` tags within `.content` blocks and it all works correctly.