### PR TITLE
Task sort

### DIFF
--- a/app/assets/js/src/components/CompletedTaskList.test.tsx
+++ b/app/assets/js/src/components/CompletedTaskList.test.tsx
@@ -1,0 +1,60 @@
+import { h } from 'preact';
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+
+import { TaskStatus } from 'types/TaskStatus';
+import { clear, setTaskInfo } from 'data';
+
+import { CompletedTaskList } from './CompletedTaskList';
+
+describe('CompletedTaskList', () => {
+	beforeEach(() => {
+		clear();
+
+		setTaskInfo(1, {
+			name: 'Task one',
+			status: TaskStatus.IN_PROGRESS,
+			sortIndex: 1,
+		});
+		setTaskInfo(2, {
+			name: 'Task two',
+			status: TaskStatus.COMPLETED,
+			sortIndex: 3,
+		});
+		setTaskInfo(3, {
+			name: 'Task three',
+			status: TaskStatus.WILL_NOT_DO,
+			sortIndex: 2,
+		});
+		setTaskInfo(4, {
+			name: 'Task four',
+			status: TaskStatus.INVESTIGATING,
+			sortIndex: -1,
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders all completed tasks', () => {
+		const { queryByText } = render(<CompletedTaskList />);
+
+		expect(queryByText('Task two')).toBeInTheDocument();
+		expect(queryByText('Task three')).toBeInTheDocument();
+
+		expect(queryByText('Task one')).not.toBeInTheDocument();
+		expect(queryByText('Task four')).not.toBeInTheDocument();
+	});
+
+	test.todo('updates tasks\' sortIndices and saves when reordering');
+});

--- a/app/assets/js/src/components/CompletedTaskList.test.tsx
+++ b/app/assets/js/src/components/CompletedTaskList.test.tsx
@@ -55,6 +55,4 @@ describe('CompletedTaskList', () => {
 		expect(queryByText('Task one')).not.toBeInTheDocument();
 		expect(queryByText('Task four')).not.toBeInTheDocument();
 	});
-
-	test.todo('updates tasks\' sortIndices and saves when reordering');
 });

--- a/app/assets/js/src/components/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/CompletedTaskList.tsx
@@ -2,7 +2,10 @@ import { h, type JSX } from 'preact';
 import { useCallback } from 'preact/hooks';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
-import { type TaskInfo } from 'data';
+import { setTaskInfo, type TaskInfo } from 'data';
+
+import { Command } from 'types/Command';
+import { fireCommand } from 'registers/commands';
 
 import { TaskList } from './TaskList';
 
@@ -21,6 +24,12 @@ export function CompletedTaskList(): JSX.Element | null {
 				[]
 			)}
 			className="orange-twist__task-list"
+			onReorder={(taskIds) => {
+				taskIds.forEach((taskId, sortIndex) => {
+					setTaskInfo(taskId, { sortIndex });
+				});
+				fireCommand(Command.DATA_SAVE);
+			}}
 		/>
 	</details>;
 }

--- a/app/assets/js/src/components/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/CompletedTaskList.tsx
@@ -2,7 +2,7 @@ import { h, type JSX } from 'preact';
 import { useCallback } from 'preact/hooks';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
-import { setTaskInfo, type TaskInfo } from 'data';
+import { setAllTaskInfo, type TaskInfo } from 'data';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -25,9 +25,10 @@ export function CompletedTaskList(): JSX.Element | null {
 			)}
 			className="orange-twist__task-list"
 			onReorder={(taskIds) => {
-				taskIds.forEach((taskId, sortIndex) => {
-					setTaskInfo(taskId, { sortIndex });
-				});
+				const entries = taskIds.map(
+					(taskId, sortIndex) => [taskId, { sortIndex }] as const
+				);
+				setAllTaskInfo(entries);
 				fireCommand(Command.DATA_SAVE);
 			}}
 		/>

--- a/app/assets/js/src/components/TaskList.test.tsx
+++ b/app/assets/js/src/components/TaskList.test.tsx
@@ -1,0 +1,87 @@
+import { h } from 'preact';
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+
+import { TaskStatus } from 'types/TaskStatus';
+import { clear, setTaskInfo } from 'data';
+
+import { TaskList } from './TaskList';
+
+describe('TaskList', () => {
+	beforeEach(() => {
+		clear();
+
+		setTaskInfo(1, {
+			name: 'Task one',
+			status: TaskStatus.IN_PROGRESS,
+			sortIndex: 1,
+		});
+		setTaskInfo(2, {
+			name: 'Task two',
+			status: TaskStatus.COMPLETED,
+			sortIndex: 3,
+		});
+		setTaskInfo(3, {
+			name: 'Task three',
+			status: TaskStatus.INVESTIGATING,
+			sortIndex: 2,
+		});
+		setTaskInfo(4, {
+			name: 'Task four',
+			status: TaskStatus.COMPLETED,
+			sortIndex: -1,
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders a specified array of tasks in order', () => {
+		const { queryAllByText } = render(<TaskList
+			matcher={[3, 2, 1]}
+		/>);
+
+		const tasks = queryAllByText(/^Task /);
+		expect(tasks.map(({ textContent }) => textContent)).toEqual([
+			'Task three',
+			'Task two',
+			'Task one',
+		]);
+	});
+
+	test('renders all tasks matching a matcher function', () => {
+		const { queryByText } = render(<TaskList
+			matcher={(task) => task.status === TaskStatus.COMPLETED}
+		/>);
+
+		expect(queryByText('Task two')).toBeInTheDocument();
+		expect(queryByText('Task four')).toBeInTheDocument();
+
+		expect(queryByText('Task one')).not.toBeInTheDocument();
+		expect(queryByText('Task three')).not.toBeInTheDocument();
+	});
+
+	test('when using a matching function, sorts tasks by sortIndex', () => {
+		const { queryAllByText } = render(<TaskList
+			matcher={() => true}
+		/>);
+
+		const tasks = queryAllByText(/^Task /);
+		expect(tasks.map(({ textContent }) => textContent)).toEqual([
+			'Task four',
+			'Task one',
+			'Task three',
+			'Task two',
+		]);
+	});
+});

--- a/app/assets/js/src/components/TaskList.test.tsx
+++ b/app/assets/js/src/components/TaskList.test.tsx
@@ -5,11 +5,12 @@ import {
 	beforeEach,
 	describe,
 	expect,
+	jest,
 	test,
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { cleanup, render } from '@testing-library/preact';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
 
 import { TaskStatus } from 'types/TaskStatus';
 import { clear, setTaskInfo } from 'data';
@@ -84,6 +85,4 @@ describe('TaskList', () => {
 			'Task two',
 		]);
 	});
-
-	test.todo('fires onreorder event when sorting');
 });

--- a/app/assets/js/src/components/TaskList.test.tsx
+++ b/app/assets/js/src/components/TaskList.test.tsx
@@ -84,4 +84,6 @@ describe('TaskList', () => {
 			'Task two',
 		]);
 	});
+
+	test.todo('fires onreorder event when sorting');
 });

--- a/app/assets/js/src/components/TaskList.tsx
+++ b/app/assets/js/src/components/TaskList.tsx
@@ -57,8 +57,13 @@ export function TaskList(
 			};
 		}
 
-		// Otherwise, don't apply any sorting rules
-		return null;
+		// Otherwise, sort by sortIndex
+		return (
+			{ sortIndex: indexA }: TaskInfo,
+			{ sortIndex: indexB }: TaskInfo
+		) => {
+			return indexA - indexB;
+		};
 	}, [matcher]);
 
 	// Sort task info if necessary

--- a/app/assets/js/src/components/UnfinishedTaskList.test.tsx
+++ b/app/assets/js/src/components/UnfinishedTaskList.test.tsx
@@ -1,0 +1,60 @@
+import { h } from 'preact';
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+
+import { TaskStatus } from 'types/TaskStatus';
+import { clear, setTaskInfo } from 'data';
+
+import { UnfinishedTaskList } from './UnfinishedTaskList';
+
+describe('UnfinishedTaskList', () => {
+	beforeEach(() => {
+		clear();
+
+		setTaskInfo(1, {
+			name: 'Task one',
+			status: TaskStatus.IN_PROGRESS,
+			sortIndex: 1,
+		});
+		setTaskInfo(2, {
+			name: 'Task two',
+			status: TaskStatus.COMPLETED,
+			sortIndex: 3,
+		});
+		setTaskInfo(3, {
+			name: 'Task three',
+			status: TaskStatus.WILL_NOT_DO,
+			sortIndex: 2,
+		});
+		setTaskInfo(4, {
+			name: 'Task four',
+			status: TaskStatus.INVESTIGATING,
+			sortIndex: -1,
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders all unfinished tasks', () => {
+		const { queryByText } = render(<UnfinishedTaskList />);
+
+		expect(queryByText('Task one')).toBeInTheDocument();
+		expect(queryByText('Task four')).toBeInTheDocument();
+
+		expect(queryByText('Task two')).not.toBeInTheDocument();
+		expect(queryByText('Task three')).not.toBeInTheDocument();
+	});
+
+	test.todo('updates tasks\' sortIndices and saves when reordering');
+});

--- a/app/assets/js/src/components/UnfinishedTaskList.test.tsx
+++ b/app/assets/js/src/components/UnfinishedTaskList.test.tsx
@@ -55,6 +55,4 @@ describe('UnfinishedTaskList', () => {
 		expect(queryByText('Task two')).not.toBeInTheDocument();
 		expect(queryByText('Task three')).not.toBeInTheDocument();
 	});
-
-	test.todo('updates tasks\' sortIndices and saves when reordering');
 });

--- a/app/assets/js/src/components/UnfinishedTaskList.tsx
+++ b/app/assets/js/src/components/UnfinishedTaskList.tsx
@@ -4,17 +4,17 @@ import { useCallback } from 'preact/hooks';
 import { classNames } from 'util/index';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
+import { setTaskInfo, type TaskInfo } from 'data';
+
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
-
-import { type TaskInfo } from 'data';
 
 import { TaskList } from './TaskList';
 
 /**
  * Renders a {@linkcode TaskList} of all unfinished tasks in a disclosure.
  */
-export function UnfinishedTasksList(): JSX.Element {
+export function UnfinishedTaskList(): JSX.Element {
 	return <section
 		class={classNames({
 			'orange-twist__section': true,
@@ -28,6 +28,12 @@ export function UnfinishedTasksList(): JSX.Element {
 				[]
 			)}
 			className="orange-twist__task-list"
+			onReorder={(taskIds) => {
+				taskIds.forEach((taskId, sortIndex) => {
+					setTaskInfo(taskId, { sortIndex });
+				});
+				fireCommand(Command.DATA_SAVE);
+			}}
 		/>
 
 		<button

--- a/app/assets/js/src/components/UnfinishedTaskList.tsx
+++ b/app/assets/js/src/components/UnfinishedTaskList.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'preact/hooks';
 import { classNames } from 'util/index';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
-import { setTaskInfo, type TaskInfo } from 'data';
+import { setAllTaskInfo, type TaskInfo } from 'data';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -29,9 +29,10 @@ export function UnfinishedTaskList(): JSX.Element {
 			)}
 			className="orange-twist__task-list"
 			onReorder={(taskIds) => {
-				taskIds.forEach((taskId, sortIndex) => {
-					setTaskInfo(taskId, { sortIndex });
-				});
+				const entries = taskIds.map(
+					(taskId, sortIndex) => [taskId, { sortIndex }] as const
+				);
+				setAllTaskInfo(entries);
 				fireCommand(Command.DATA_SAVE);
 			}}
 		/>

--- a/app/assets/js/src/data/dayTasks/setDayTaskInfo.test.ts
+++ b/app/assets/js/src/data/dayTasks/setDayTaskInfo.test.ts
@@ -46,6 +46,7 @@ describe('setDayTaskInfo', () => {
 			name: 'New task',
 			status: TaskStatus.IN_PROGRESS,
 			note: '',
+			sortIndex: -1,
 		});
 
 		expect(getDayInfo('2023-11-12')).toEqual({

--- a/app/assets/js/src/data/index.ts
+++ b/app/assets/js/src/data/index.ts
@@ -18,6 +18,7 @@ export {
 
 	createTask,
 	setTaskInfo,
+	setAllTaskInfo,
 	deleteTask,
 	getTaskInfo,
 	getAllTaskInfo,

--- a/app/assets/js/src/data/shared/exportData/writeExportData.test.ts
+++ b/app/assets/js/src/data/shared/exportData/writeExportData.test.ts
@@ -49,6 +49,7 @@ describe('writeExportData', () => {
 				name: 'Test task',
 				note: 'Task note',
 				status: TaskStatus.TODO,
+				sortIndex: -1,
 			}]],
 			dayTasks: [['2023-12-11_1', {
 				dayName: '2023-12-11',

--- a/app/assets/js/src/data/shared/importData/importData.ts
+++ b/app/assets/js/src/data/shared/importData/importData.ts
@@ -15,6 +15,7 @@ export async function importData(): Promise<void> {
 			return await readExportDataFromFile();
 		} catch (e) {
 			ui.alert('Selected file doesn\'t contain valid data');
+			console.error(e);
 			return;
 		}
 	})();

--- a/app/assets/js/src/data/shared/importData/loadExportData.test.ts
+++ b/app/assets/js/src/data/shared/importData/loadExportData.test.ts
@@ -71,11 +71,8 @@ describe('loadExportData', () => {
 
 	test('returns a Promise that rejects when incorrect export data is passed', async () => {
 		const result = loadExportData({
-			// @ts-expect-error Checking invalid data
 			days: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			tasks: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			dayTasks: [[true, null]],
 		});
 
@@ -107,11 +104,8 @@ describe('loadExportData', () => {
 		setDayTaskInfo(testDayTask, testDayTask);
 
 		const result = loadExportData({
-			// @ts-expect-error Checking invalid data
 			days: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			tasks: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			dayTasks: [[true, null]],
 		});
 
@@ -156,11 +150,8 @@ describe('loadExportData', () => {
 		}, { forCurrentDay: false });
 
 		const result = loadExportData({
-			// @ts-expect-error Checking invalid data
 			days: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			tasks: [[true, null]],
-			// @ts-expect-error Checking invalid data
 			dayTasks: [[true, null]],
 		});
 
@@ -191,7 +182,6 @@ describe('loadExportData', () => {
 
 		const result = loadExportData({
 			days: [[testDay.name, testDay]],
-			// @ts-expect-error Using old form of data
 			tasks: [[testTask.id, testTask]],
 			dayTasks: [[`${testDay.name}_${testTask.id}`, testDayTask]],
 		});

--- a/app/assets/js/src/data/shared/importData/loadExportData.test.ts
+++ b/app/assets/js/src/data/shared/importData/loadExportData.test.ts
@@ -88,6 +88,7 @@ describe('loadExportData', () => {
 			name: 'Task name',
 			note: 'Task note',
 			status: TaskStatus.TODO,
+			sortIndex: -1,
 		};
 		const testDay: DayInfo = {
 			name: '2023-12-11',
@@ -127,6 +128,7 @@ describe('loadExportData', () => {
 			name: 'Task name',
 			note: 'Task note',
 			status: TaskStatus.TODO,
+			sortIndex: -1,
 		};
 		const testDay: DayInfo = {
 			name: '2023-12-11',
@@ -199,6 +201,7 @@ describe('loadExportData', () => {
 		expect(getAllTaskInfo()).toEqual([{
 			...testTask,
 			note: '',
+			sortIndex: -1,
 		}]);
 		expect(getAllDayInfo()).toEqual([testDay]);
 		expect(getAllDayTaskInfo()).toEqual([testDayTask]);

--- a/app/assets/js/src/data/shared/importData/loadExportData.ts
+++ b/app/assets/js/src/data/shared/importData/loadExportData.ts
@@ -1,4 +1,4 @@
-import type { ExportData } from '../types/ExportData';
+import type { ExportDataLike } from '../types/ExportDataLike';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -13,7 +13,7 @@ import { writeExportData } from '../exportData/writeExportData';
  * Try to load a set of data directly into memory.
  * If it fails, the Promise it returns will reject.
  */
-async function loadExportDataDirect(data: ExportData): Promise<void> {
+async function loadExportDataDirect(data: ExportDataLike): Promise<void> {
 	await Promise.all([
 		loadDays(JSON.stringify(data.days)),
 		loadTasks(JSON.stringify(data.tasks)),
@@ -25,7 +25,7 @@ async function loadExportDataDirect(data: ExportData): Promise<void> {
  * Try to load a set of data directly into memory.
  * If it fails, restores a backup.
  */
-export async function loadExportData(data: ExportData): Promise<void> {
+export async function loadExportData(data: ExportDataLike): Promise<void> {
 	// Take a backup in case we hit an error
 	const backup = writeExportData();
 

--- a/app/assets/js/src/data/shared/importData/readExportDataFromFile.ts
+++ b/app/assets/js/src/data/shared/importData/readExportDataFromFile.ts
@@ -1,26 +1,22 @@
 import { chooseFile, readFileAsString } from 'util/index';
 
-import { isExportData, type ExportData } from '../types/ExportData';
+import { isExportDataLike, type ExportDataLike } from '../types/ExportDataLike';
 
 /**
  * Prompt the user to select a file, then attempt to read its
  * contents as ExportData.
  */
-export async function readExportDataFromFile(): Promise<ExportData | null> {
+export async function readExportDataFromFile(): Promise<ExportDataLike | null> {
 	const file = await chooseFile('application/json');
 	if (!file) {
 		return null;
 	}
 
 	const dataString = await readFileAsString(file);
-	try {
-		const data = JSON.parse(dataString);
-		if (!isExportData(data)) {
-			throw new Error('Selected file does not contain valid export data');
-		}
-
-		return data;
-	} catch (e) {
-		throw new Error('Could not parse selected file as JSON');
+	const data = JSON.parse(dataString);
+	if (!isExportDataLike(data)) {
+		throw new Error('Selected file\'s contents are not shaped like export data');
 	}
+
+	return data;
 }

--- a/app/assets/js/src/data/shared/types/ExportData.ts
+++ b/app/assets/js/src/data/shared/types/ExportData.ts
@@ -5,8 +5,12 @@ import { isZodSchemaType } from 'util/index';
 import { dayInfoSchema } from 'data/days/types/DayInfo';
 import { taskInfoSchema } from 'data/tasks/types/TaskInfo';
 import { dayTaskInfoSchema } from 'data/dayTasks/types/DayTaskInfo';
+import { exportDataLikeSchema } from './ExportDataLike';
 
-const exportDataSchema = z.object({
+/**
+ * Strict export data format used when constructing export data.
+ */
+const exportDataSchema = exportDataLikeSchema.extend({
 	days: z.array(
 		z.tuple([
 			z.string(),
@@ -26,7 +30,6 @@ const exportDataSchema = z.object({
 		]),
 	),
 });
-
 export type ExportData = z.infer<typeof exportDataSchema>;
-
 export const isExportData = isZodSchemaType(exportDataSchema);
+

--- a/app/assets/js/src/data/shared/types/ExportDataLike.ts
+++ b/app/assets/js/src/data/shared/types/ExportDataLike.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { isZodSchemaType } from 'util/index';
+
+/**
+ * Unstrict export data used when importing data, which may be
+ * in an old form. Any validation or updating will be done when
+ * it is loaded.
+ */
+export const exportDataLikeSchema = z.object({
+	days: z.unknown(),
+	tasks: z.unknown(),
+	dayTasks: z.unknown(),
+});
+export type ExportDataLike = z.infer<typeof exportDataLikeSchema>;
+export const isExportDataLike = isZodSchemaType(exportDataLikeSchema);

--- a/app/assets/js/src/data/tasks/createTask.test.ts
+++ b/app/assets/js/src/data/tasks/createTask.test.ts
@@ -41,6 +41,7 @@ describe('createTask', () => {
 			name: 'New task',
 			status: TaskStatus.TODO,
 			note: '',
+			sortIndex: -1,
 		});
 	});
 
@@ -54,12 +55,14 @@ describe('createTask', () => {
 			name: 'Custom task name',
 			status: TaskStatus.TODO,
 			note: '',
+			sortIndex: -1,
 		});
 
 		const newIdFull = createTask({
 			name: 'Custom task name',
 			status: TaskStatus.IN_PROGRESS,
 			note: 'Custom task note',
+			sortIndex: -1,
 		} satisfies Omit<TaskInfo, 'id'>);
 
 		expect(getTaskInfo(newIdFull)).toEqual({
@@ -67,6 +70,7 @@ describe('createTask', () => {
 			name: 'Custom task name',
 			status: TaskStatus.IN_PROGRESS,
 			note: 'Custom task note',
+			sortIndex: -1,
 		});
 	});
 

--- a/app/assets/js/src/data/tasks/getAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/getAllTaskInfo.test.ts
@@ -18,6 +18,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -25,6 +26,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 describe('getAllTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/getDefaultTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/getDefaultTaskInfo.ts
@@ -1,0 +1,14 @@
+import { TaskStatus } from 'types/TaskStatus';
+import type { TaskInfo } from './types';
+
+/**
+ * Determine default task info, used to fill in any blanks.
+ */
+export function getDefaultTaskInfo(taskId: number): Omit<TaskInfo, 'id'> {
+	return {
+		name: 'New task',
+		status: TaskStatus.TODO,
+		note: '',
+		sortIndex: -Math.abs(taskId),
+	};
+}

--- a/app/assets/js/src/data/tasks/getTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/getTaskInfo.test.ts
@@ -18,6 +18,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -25,6 +26,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 describe('getTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/hooks/useAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/hooks/useAllTaskInfo.test.ts
@@ -24,6 +24,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -31,6 +32,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 const thirdTaskInfo: TaskInfo = {
@@ -38,6 +40,7 @@ const thirdTaskInfo: TaskInfo = {
 	name: 'Third task',
 	status: TaskStatus.COMPLETED,
 	note: 'Task note',
+	sortIndex: -1,
 };
 
 describe('useAllTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/hooks/useTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/hooks/useTaskInfo.test.ts
@@ -22,6 +22,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -29,6 +30,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 const thirdTaskInfo: TaskInfo = {
@@ -36,6 +38,7 @@ const thirdTaskInfo: TaskInfo = {
 	name: 'Third task',
 	status: TaskStatus.COMPLETED,
 	note: 'Task note',
+	sortIndex: -1,
 };
 
 describe('useTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/index.ts
+++ b/app/assets/js/src/data/tasks/index.ts
@@ -2,6 +2,7 @@ export type { TaskInfo } from './types';
 
 export { createTask } from './createTask';
 export { setTaskInfo } from './setTaskInfo';
+export { setAllTaskInfo } from './setAllTaskInfo';
 export { deleteTask } from './deleteTask';
 export { getTaskInfo } from './getTaskInfo';
 export { getAllTaskInfo } from './getAllTaskInfo';

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.test.ts
@@ -19,6 +19,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -26,6 +27,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 describe('loadTasks', () => {
@@ -127,6 +129,7 @@ describe('loadTasks', () => {
 				name: 'Task name',
 				status: TaskStatus.IN_PROGRESS,
 				note: '',
+				sortIndex: -1,
 			}],
 		]));
 		expect(Array.from(tasksRegister.entries())).toEqual([
@@ -135,6 +138,7 @@ describe('loadTasks', () => {
 				name: 'Task name',
 				status: TaskStatus.IN_PROGRESS,
 				note: '',
+				sortIndex: -1,
 			}],
 		]);
 	});

--- a/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
@@ -18,6 +18,7 @@ const firstTaskInfo: TaskInfo = {
 	name: 'First task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 };
 
 const secondTaskInfo: TaskInfo = {
@@ -25,6 +26,7 @@ const secondTaskInfo: TaskInfo = {
 	name: 'Second task',
 	status: TaskStatus.IN_PROGRESS,
 	note: 'Note',
+	sortIndex: -1,
 };
 
 describe('saveDays', () => {

--- a/app/assets/js/src/data/tasks/setAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/setAllTaskInfo.test.ts
@@ -1,0 +1,111 @@
+import {
+	beforeEach,
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
+
+import { tasksRegister } from './tasksRegister';
+
+import { setAllTaskInfo } from './setAllTaskInfo';
+import { clear, getAllTaskInfo, getTaskInfo, setTaskInfo } from 'data';
+import { TaskStatus } from 'types/TaskStatus';
+
+describe('setAllTaskInfo', () => {
+	beforeEach(() => {
+		clear();
+	});
+
+	test('sets info for multiple tasks', () => {
+		setAllTaskInfo([
+			[1, { name: 'Task one' }],
+			[2, { name: 'Task two' }],
+		]);
+
+		expect(getAllTaskInfo()).toEqual([
+			{
+				id: 1,
+				name: 'Task one',
+				note: '',
+				status: TaskStatus.TODO,
+				sortIndex: -1,
+			},
+			{
+				id: 2,
+				name: 'Task two',
+				note: '',
+				status: TaskStatus.TODO,
+				sortIndex: -2,
+			},
+		]);
+	});
+
+	test('when not overriding values, persists previous values', () => {
+		setTaskInfo(1, {
+			name: 'Task name',
+			note: 'Task note',
+			status: TaskStatus.IN_PROGRESS,
+			sortIndex: 1,
+		});
+
+		setAllTaskInfo([[1, {}]]);
+
+		expect(getTaskInfo(1)).toEqual({
+			id: 1,
+			name: 'Task name',
+			note: 'Task note',
+			status: TaskStatus.IN_PROGRESS,
+			sortIndex: 1,
+		});
+	});
+
+	test('when creating a new task, fills in any blanks with default values', () => {
+		setAllTaskInfo([[2, {}]]);
+
+		expect(getTaskInfo(2)).toEqual({
+			id: 2,
+			name: 'New task',
+			note: '',
+			status: TaskStatus.TODO,
+			sortIndex: -2,
+		});
+	});
+
+	test('causes a single "set" event to be emitted on the tasks register', () => {
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		const spy = jest.fn();
+
+		tasksRegister.addEventListener('set', spy, { signal });
+
+		setAllTaskInfo([[1, {}], [2, {}]]);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith([
+			{
+				key: 1,
+				value: {
+					id: 1,
+					name: 'New task',
+					note: '',
+					status: TaskStatus.TODO,
+					sortIndex: -1,
+				},
+			},
+			{
+				key: 2,
+				value: {
+					id: 2,
+					name: 'New task',
+					note: '',
+					status: TaskStatus.TODO,
+					sortIndex: -2,
+				},
+			},
+		]);
+
+		controller.abort();
+	});
+});

--- a/app/assets/js/src/data/tasks/setAllTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setAllTaskInfo.ts
@@ -7,9 +7,9 @@ import { getTaskInfo } from 'data';
 /**
  * Sets or updates task info for multiple tasks.
  */
-export function setAllTaskInfo(entries: [
+export function setAllTaskInfo(entries: readonly (readonly[
 	taskId: number, taskInfo: Partial<Omit<TaskInfo, 'id'>>
-][]): void {
+])[]): void {
 	const fullEntries = entries.map(([taskId, taskInfo]) => {
 		const existingTaskInfo = getTaskInfo(taskId);
 		if (existingTaskInfo) {

--- a/app/assets/js/src/data/tasks/setAllTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setAllTaskInfo.ts
@@ -1,0 +1,42 @@
+import type { TaskInfo } from './types';
+
+import { tasksRegister } from './tasksRegister';
+import { getDefaultTaskInfo } from './getDefaultTaskInfo';
+import { getTaskInfo } from 'data';
+
+/**
+ * Sets or updates task info for multiple tasks.
+ */
+export function setAllTaskInfo(entries: [
+	taskId: number, taskInfo: Partial<Omit<TaskInfo, 'id'>>
+][]): void {
+	const fullEntries = entries.map(([taskId, taskInfo]) => {
+		const existingTaskInfo = getTaskInfo(taskId);
+		if (existingTaskInfo) {
+			return [
+				taskId,
+				{
+					id: taskId,
+					name: taskInfo.name ?? existingTaskInfo.name,
+					status: taskInfo.status ?? existingTaskInfo.status,
+					note: taskInfo.note ?? existingTaskInfo.note,
+					sortIndex: taskInfo.sortIndex ?? existingTaskInfo.sortIndex,
+				},
+			] as const;
+		}
+
+		const defaultTaskInfo = getDefaultTaskInfo(taskId);
+		return [
+			taskId,
+			{
+				id: taskId,
+				name: taskInfo.name ?? defaultTaskInfo.name,
+				status: taskInfo.status ?? defaultTaskInfo.status,
+				note: taskInfo.note ?? defaultTaskInfo.note,
+				sortIndex: taskInfo.sortIndex ?? defaultTaskInfo.sortIndex,
+			},
+		] as const;
+	});
+
+	tasksRegister.set(fullEntries);
+}

--- a/app/assets/js/src/data/tasks/setTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.test.ts
@@ -65,6 +65,12 @@ describe('setTaskInfo', () => {
 		});
 	});
 
+	test('defaults sortIndex based on task ID', () => {
+		setTaskInfo(3, {});
+
+		expect(getTaskInfo(3)?.sortIndex).toBe(-3);
+	});
+
 	describe('when setting the status for a task', () => {
 		test('if the "forCurrentDay" option is absent or true, also updates the day task for the current day', () => {
 			const currentDayName = getCurrentDateDayName();

--- a/app/assets/js/src/data/tasks/setTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.test.ts
@@ -31,6 +31,7 @@ describe('setTaskInfo', () => {
 				name: 'Task name',
 				status: TaskStatus.IN_PROGRESS,
 				note: 'Task note',
+				sortIndex: -1,
 			} satisfies Omit<TaskInfo, 'id'> // <- Ensure we're testing every option
 		);
 
@@ -39,6 +40,7 @@ describe('setTaskInfo', () => {
 			name: 'Task name',
 			status: TaskStatus.IN_PROGRESS,
 			note: 'Task note',
+			sortIndex: -1,
 		});
 	});
 
@@ -47,6 +49,7 @@ describe('setTaskInfo', () => {
 			name: 'Task name',
 			status: TaskStatus.TODO,
 			note: 'Task note',
+			sortIndex: -1,
 		} satisfies Omit<TaskInfo, 'id'>);
 
 		setTaskInfo(1, {
@@ -58,6 +61,7 @@ describe('setTaskInfo', () => {
 			name: 'Updated name',
 			status: TaskStatus.TODO,
 			note: 'Task note',
+			sortIndex: -1,
 		});
 	});
 

--- a/app/assets/js/src/data/tasks/setTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.ts
@@ -10,6 +10,7 @@ const defaultTaskInfo = {
 	name: 'New task',
 	status: TaskStatus.TODO,
 	note: '',
+	sortIndex: -1,
 } as const satisfies Omit<TaskInfo, 'id'>;
 
 interface SetTaskInfoOptions {
@@ -51,6 +52,7 @@ export function setTaskInfo(
 		name: taskInfo.name ?? existingTaskInfo?.name ?? defaultTaskInfo.name,
 		status: taskInfo.status ?? existingTaskInfo?.status ?? defaultTaskInfo.status,
 		note: taskInfo.note ?? existingTaskInfo?.note ?? defaultTaskInfo.note,
+		sortIndex: taskInfo.sortIndex ?? existingTaskInfo?.sortIndex ?? defaultTaskInfo.sortIndex,
 	});
 
 	if (consolidatedOptions.forCurrentDay && taskInfo.status) {

--- a/app/assets/js/src/data/tasks/setTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.ts
@@ -3,20 +3,8 @@ import type { TaskInfo } from './types';
 import { getCurrentDateDayName } from 'util/index';
 
 import { tasksRegister } from './tasksRegister';
-import { TaskStatus } from 'types/TaskStatus';
 import { getDayTaskInfo, setDayTaskInfo } from 'data/dayTasks';
-
-/**
- * Determine default task info, used to fill in any blanks.
- */
-function getDefaultTaskInfo(taskId: number): Omit<TaskInfo, 'id'> {
-	return {
-		name: 'New task',
-		status: TaskStatus.TODO,
-		note: '',
-		sortIndex: -Math.abs(taskId),
-	};
-}
+import { getDefaultTaskInfo } from './getDefaultTaskInfo';
 
 interface SetTaskInfoOptions {
 	/**
@@ -51,15 +39,26 @@ export function setTaskInfo(
 	};
 
 	const existingTaskInfo = tasksRegister.get(taskId);
-	const defaultTaskInfo = getDefaultTaskInfo(taskId);
-	tasksRegister.set(taskId, {
-		id: taskId,
+	if (existingTaskInfo) {
+		tasksRegister.set(taskId, {
+			id: taskId,
 
-		name: taskInfo.name ?? existingTaskInfo?.name ?? defaultTaskInfo.name,
-		status: taskInfo.status ?? existingTaskInfo?.status ?? defaultTaskInfo.status,
-		note: taskInfo.note ?? existingTaskInfo?.note ?? defaultTaskInfo.note,
-		sortIndex: taskInfo.sortIndex ?? existingTaskInfo?.sortIndex ?? defaultTaskInfo.sortIndex,
-	});
+			name: taskInfo.name ?? existingTaskInfo?.name,
+			status: taskInfo.status ?? existingTaskInfo?.status,
+			note: taskInfo.note ?? existingTaskInfo?.note,
+			sortIndex: taskInfo.sortIndex ?? existingTaskInfo?.sortIndex,
+		});
+	} else {
+		const defaultTaskInfo = getDefaultTaskInfo(taskId);
+		tasksRegister.set(taskId, {
+			id: taskId,
+
+			name: taskInfo.name ?? defaultTaskInfo.name,
+			status: taskInfo.status ?? defaultTaskInfo.status,
+			note: taskInfo.note ?? defaultTaskInfo.note,
+			sortIndex: taskInfo.sortIndex ?? defaultTaskInfo.sortIndex,
+		});
+	}
 
 	if (consolidatedOptions.forCurrentDay && taskInfo.status) {
 		const dayName = getCurrentDateDayName();

--- a/app/assets/js/src/data/tasks/setTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/setTaskInfo.ts
@@ -6,12 +6,17 @@ import { tasksRegister } from './tasksRegister';
 import { TaskStatus } from 'types/TaskStatus';
 import { getDayTaskInfo, setDayTaskInfo } from 'data/dayTasks';
 
-const defaultTaskInfo = {
-	name: 'New task',
-	status: TaskStatus.TODO,
-	note: '',
-	sortIndex: -1,
-} as const satisfies Omit<TaskInfo, 'id'>;
+/**
+ * Determine default task info, used to fill in any blanks.
+ */
+function getDefaultTaskInfo(taskId: number): Omit<TaskInfo, 'id'> {
+	return {
+		name: 'New task',
+		status: TaskStatus.TODO,
+		note: '',
+		sortIndex: -Math.abs(taskId),
+	};
+}
 
 interface SetTaskInfoOptions {
 	/**
@@ -46,6 +51,7 @@ export function setTaskInfo(
 	};
 
 	const existingTaskInfo = tasksRegister.get(taskId);
+	const defaultTaskInfo = getDefaultTaskInfo(taskId);
 	tasksRegister.set(taskId, {
 		id: taskId,
 

--- a/app/assets/js/src/data/tasks/types/TaskInfo.ts
+++ b/app/assets/js/src/data/tasks/types/TaskInfo.ts
@@ -8,7 +8,7 @@ export const taskInfoSchema = z.object({
 	name: z.string(),
 	status: z.nativeEnum(TaskStatus),
 	note: z.string(),
-	/** Used for sorting tasks. Defaults to -1 */
+	/** Used for sorting tasks. */
 	sortIndex: z.number(),
 });
 

--- a/app/assets/js/src/data/tasks/types/TaskInfo.ts
+++ b/app/assets/js/src/data/tasks/types/TaskInfo.ts
@@ -8,6 +8,8 @@ export const taskInfoSchema = z.object({
 	name: z.string(),
 	status: z.nativeEnum(TaskStatus),
 	note: z.string(),
+	/** Used for sorting tasks. Defaults to -1 */
+	sortIndex: z.number(),
 });
 
 /**

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
@@ -11,7 +11,7 @@ describe('updateOldTaskInfo', () => {
 		}).toThrow();
 	});
 
-	test('correctly migrates task data from schema version 1, adds an empty note', () => {
+	test('correctly migrates task data from schema version 1', () => {
 		const result = updateOldTaskInfo({
 			id: 1,
 			name: 'Task name',
@@ -23,6 +23,24 @@ describe('updateOldTaskInfo', () => {
 			name: 'Task name',
 			status: TaskStatus.IN_PROGRESS,
 			note: '',
+			sortIndex: -1,
+		});
+	});
+
+	test('correctly migrates task data from schema version 2', () => {
+		const result = updateOldTaskInfo({
+			id: 1,
+			name: 'Task name',
+			status: TaskStatus.IN_PROGRESS,
+			note: 'Task note',
+		});
+
+		expect(result).toEqual({
+			id: 1,
+			name: 'Task name',
+			status: TaskStatus.IN_PROGRESS,
+			note: 'Task note',
+			sortIndex: -1,
 		});
 	});
 });

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.ts
@@ -28,6 +28,16 @@ const oldTaskInfoSchemas = [
 			note: z.string(),
 		}).strict(),
 	],
+	[
+		3,
+		z.object({
+			id: z.number(),
+			name: z.string(),
+			status: z.nativeEnum(TaskStatus),
+			note: z.string(),
+			sortIndex: z.number(),
+		}).strict(),
+	],
 ] as const satisfies ReadonlyArray<readonly [number, z.ZodType]>;
 
 /**
@@ -83,6 +93,11 @@ export function updateOldTaskInfo(val: unknown): TaskInfo {
 			note: '',
 		};
 	} else if (oldTaskInfoVersion === 2) {
+		newVal = {
+			...oldVal,
+			sortIndex: -1,
+		};
+	} else if (oldTaskInfoVersion === 3) {
 		// No migration currently needed
 		newVal = oldVal;
 	} else {

--- a/app/assets/js/src/main.tsx
+++ b/app/assets/js/src/main.tsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact';
 
 import { OrangeTwist } from './components/OrangeTwist';
 import { DayList } from './components/DaysList';
-import { UnfinishedTasksList } from './components/UnfinishedTaskList';
+import { UnfinishedTaskList } from './components/UnfinishedTaskList';
 import { CompletedTaskList } from './components/CompletedTaskList';
 
 const main = document.getElementById('main');
@@ -13,7 +13,7 @@ if (main === null) {
 render(<OrangeTwist>
 	<DayList />
 
-	<UnfinishedTasksList />
+	<UnfinishedTaskList />
 
 	<CompletedTaskList />
 </OrangeTwist>, main);


### PR DESCRIPTION
Resolves #42

This PR adds sorting functionality back to the `CompletedTaskList` and `UnfinishedTaskList` components.

To accomplish this, it adds a new `sortIndex` property to `TaskInfo`. For new tasks, this is initialised to a negative number to ensure new tasks appear at the top of the list. Once a task list is sorted, the `sortIndex` is set to a positive number.

I've improved test coverage, but unfortunately haven't been able to add tests for the drag & drop behaviour because [jsdom doesn't support `DataTransfer`](https://github.com/jsdom/jsdom/issues/1568).