### PR TITLE
Config updates

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -466,5 +466,11 @@ module.exports = {
 			plugins: ['jest'],
 			extends: ['plugin:jest/recommended'],
 		},
+		{
+			files: ['scripts/**/*'],
+			rules: {
+				'no-console': 'off',
+			},
+		},
 	],
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/app/assets/js/src/components/TaskList.test.tsx
+++ b/app/assets/js/src/components/TaskList.test.tsx
@@ -5,12 +5,11 @@ import {
 	beforeEach,
 	describe,
 	expect,
-	jest,
 	test,
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { cleanup, render } from '@testing-library/preact';
 
 import { TaskStatus } from 'types/TaskStatus';
 import { clear, setTaskInfo } from 'data';

--- a/app/assets/js/src/components/shared/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown.tsx
@@ -69,28 +69,35 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 			? content.split('\n')[0]
 			: content;
 
-		let renderedContent = marked
-			.parse(contentToRender, {
+		(async () => {
+			let renderedContent = marked.parse(contentToRender, {
 				breaks: true,
-			})
-			// Stupid fucking plugin replaces tabs with spaces
-			.replace(/ {4}/g, '\t')
-			// To allow HTML tags to be written as text in task names,
-			// I replace `<` with `&lt;`. So, when displaying the rendered
-			// content, reverse it. This also means if I were type "&amp;lt;"
-			// in a task name it would become "<" but that's fine)
-			.replace(/&amp;lt;/g, '&lt;');
+			});
 
-		if (inline) {
-			renderedContent = renderedContent.replace(/<p>(.+)<\/p>\n?/, '$1');
-		}
+			if (typeof renderedContent !== 'string') {
+				renderedContent = await renderedContent;
+			}
 
-		if (wrapper.setHTML) {
-			wrapper.setHTML(renderedContent);
-		} else {
-			// `setHTML` is not supported, so falling back to vulnerable method'
-			wrapper.innerHTML = renderedContent;
-		}
+			renderedContent = renderedContent
+				// Stupid fucking plugin replaces tabs with spaces
+				.replace(/ {4}/g, '\t')
+				// To allow HTML tags to be written as text in task names,
+				// I replace `<` with `&lt;`. So, when displaying the rendered
+				// content, reverse it. This also means if I were type "&amp;lt;"
+				// in a task name it would become "<" but that's fine)
+				.replace(/&amp;lt;/g, '&lt;');
+
+			if (inline) {
+				renderedContent = renderedContent.replace(/<p>(.+)<\/p>\n?/, '$1');
+			}
+
+			if (wrapper.setHTML) {
+				wrapper.setHTML(renderedContent);
+			} else {
+				// `setHTML` is not supported, so falling back to vulnerable method'
+				wrapper.innerHTML = renderedContent;
+			}
+		})();
 	}, [content, inline]);
 
 	return <div

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,24 +9,24 @@
 			"version": "0.1.0",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
-				"marked": "^9.1.2",
-				"preact": "^10.18.1",
+				"marked": "^11.1.0",
+				"preact": "^10.19.3",
 				"zod": "^3.22.4"
 			},
 			"devDependencies": {
 				"@jest/globals": "^29.7.0",
-				"@stylistic/eslint-plugin": "^1.0.0",
-				"@testing-library/jest-dom": "^6.1.4",
+				"@stylistic/eslint-plugin": "^1.5.1",
+				"@testing-library/jest-dom": "^6.1.5",
 				"@testing-library/preact": "^3.2.3",
 				"@testing-library/user-event": "^14.5.1",
-				"@types/express": "^4.17.20",
-				"@typescript-eslint/eslint-plugin": "^6.9.0",
-				"@typescript-eslint/parser": "^6.9.0",
+				"@types/express": "^4.17.21",
+				"@typescript-eslint/eslint-plugin": "^6.14.0",
+				"@typescript-eslint/parser": "^6.14.0",
 				"concurrently": "^8.2.2",
 				"cross-env": "^7.0.3",
 				"dotenv": "^16.3.1",
-				"esbuild": "^0.19.5",
-				"eslint": "^8.52.0",
+				"esbuild": "^0.19.9",
+				"eslint": "^8.55.0",
 				"eslint-plugin-jest": "^27.6.0",
 				"eslint-plugin-react": "^7.33.2",
 				"eslint-plugin-react-hooks": "^4.6.0",
@@ -35,11 +35,11 @@
 				"jest-environment-jsdom": "^29.7.0",
 				"jsdom-testing-mocks": "^1.11.0",
 				"sass": "^1.69.5",
-				"stylelint": "^15.11.0",
-				"stylelint-config-recommended-scss": "^13.0.0",
+				"stylelint": "^16.0.2",
+				"stylelint-config-recommended-scss": "^14.0.0",
 				"ts-jest": "^29.1.1",
-				"ts-node": "^10.9.1",
-				"typescript": "^5.2.2"
+				"ts-node": "^10.9.2",
+				"typescript": "^5.3.3"
 			},
 			"engines": {
 				"node": ">=20"
@@ -55,9 +55,9 @@
 			}
 		},
 		"node_modules/@adobe/css-tools": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-			"integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+			"integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
 			"dev": true
 		},
 		"node_modules/@ampproject/remapping": {
@@ -858,9 +858,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
-			"integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.9.tgz",
+			"integrity": "sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==",
 			"cpu": [
 				"arm"
 			],
@@ -874,9 +874,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
-			"integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.9.tgz",
+			"integrity": "sha512-q4cR+6ZD0938R19MyEW3jEsMzbb/1rulLXiNAJQADD/XYp7pT+rOS5JGxvpRW8dFDEfjW4wLgC/3FXIw4zYglQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -890,9 +890,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
-			"integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.9.tgz",
+			"integrity": "sha512-KOqoPntWAH6ZxDwx1D6mRntIgZh9KodzgNOy5Ebt9ghzffOk9X2c1sPwtM9P+0eXbefnDhqYfkh5PLP5ULtWFA==",
 			"cpu": [
 				"x64"
 			],
@@ -906,9 +906,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.5.tgz",
-			"integrity": "sha512-mvXGcKqqIqyKoxq26qEDPHJuBYUA5KizJncKOAf9eJQez+L9O+KfvNFu6nl7SCZ/gFb2QPaRqqmG0doSWlgkqw==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.9.tgz",
+			"integrity": "sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==",
 			"cpu": [
 				"arm64"
 			],
@@ -922,9 +922,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
-			"integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.9.tgz",
+			"integrity": "sha512-vE0VotmNTQaTdX0Q9dOHmMTao6ObjyPm58CHZr1UK7qpNleQyxlFlNCaHsHx6Uqv86VgPmR4o2wdNq3dP1qyDQ==",
 			"cpu": [
 				"x64"
 			],
@@ -938,9 +938,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
-			"integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.9.tgz",
+			"integrity": "sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -954,9 +954,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
-			"integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.9.tgz",
+			"integrity": "sha512-WMLgWAtkdTbTu1AWacY7uoj/YtHthgqrqhf1OaEWnZb7PQgpt8eaA/F3LkV0E6K/Lc0cUr/uaVP/49iE4M4asA==",
 			"cpu": [
 				"x64"
 			],
@@ -970,9 +970,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
-			"integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.9.tgz",
+			"integrity": "sha512-C/ChPohUYoyUaqn1h17m/6yt6OB14hbXvT8EgM1ZWaiiTYz7nWZR0SYmMnB5BzQA4GXl3BgBO1l8MYqL/He3qw==",
 			"cpu": [
 				"arm"
 			],
@@ -986,9 +986,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
-			"integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.9.tgz",
+			"integrity": "sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1002,9 +1002,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
-			"integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.9.tgz",
+			"integrity": "sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -1018,9 +1018,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
-			"integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.9.tgz",
+			"integrity": "sha512-t6mN147pUIf3t6wUt3FeumoOTPfmv9Cc6DQlsVBpB7eCpLOqQDyWBP1ymXn1lDw4fNUSb/gBcKAmvTP49oIkaA==",
 			"cpu": [
 				"loong64"
 			],
@@ -1034,9 +1034,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
-			"integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.9.tgz",
+			"integrity": "sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1050,9 +1050,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
-			"integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.9.tgz",
+			"integrity": "sha512-tkV0xUX0pUUgY4ha7z5BbDS85uI7ABw3V1d0RNTii7E9lbmV8Z37Pup2tsLV46SQWzjOeyDi1Q7Wx2+QM8WaCQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1066,9 +1066,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
-			"integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.9.tgz",
+			"integrity": "sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1082,9 +1082,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
-			"integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.9.tgz",
+			"integrity": "sha512-zHbglfEdC88KMgCWpOl/zc6dDYJvWGLiUtmPRsr1OgCViu3z5GncvNVdf+6/56O2Ca8jUU+t1BW261V6kp8qdw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
-			"integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.9.tgz",
+			"integrity": "sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==",
 			"cpu": [
 				"x64"
 			],
@@ -1114,9 +1114,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
-			"integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.9.tgz",
+			"integrity": "sha512-GThgZPAwOBOsheA2RUlW5UeroRfESwMq/guy8uEe3wJlAOjpOXuSevLRd70NZ37ZrpO6RHGHgEHvPg1h3S1Jug==",
 			"cpu": [
 				"x64"
 			],
@@ -1130,9 +1130,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
-			"integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.9.tgz",
+			"integrity": "sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==",
 			"cpu": [
 				"x64"
 			],
@@ -1146,9 +1146,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
-			"integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.9.tgz",
+			"integrity": "sha512-MLHj7k9hWh4y1ddkBpvRj2b9NCBhfgBt3VpWbHQnXRedVun/hC7sIyTGDGTfsGuXo4ebik2+3ShjcPbhtFwWDw==",
 			"cpu": [
 				"x64"
 			],
@@ -1162,9 +1162,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
-			"integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.9.tgz",
+			"integrity": "sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1178,9 +1178,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
-			"integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.9.tgz",
+			"integrity": "sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1194,9 +1194,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
-			"integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.9.tgz",
+			"integrity": "sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1234,9 +1234,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-			"integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -1257,9 +1257,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.52.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-			"integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1820,59 +1820,83 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
-			"integrity": "sha512-kh4q2O2r55uKTXIQlVxnr9Pkjaemv/pn0lQ6bVRBD/ETq0hwhIvXR/54NRs3X8bS4IGIO2SGjFxnjySfUYJ3tQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.5.1.tgz",
+			"integrity": "sha512-y7ynUMh5Hq1MhYApAccl1iuQem5Sf2JSEIjV/qsBfmW1WfRDs74V+0kLkcOn1Y600W3t8orIFrrEuWmJSetAgw==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.0.0",
-				"@stylistic/eslint-plugin-jsx": "1.0.0",
-				"@stylistic/eslint-plugin-ts": "1.0.0"
+				"@stylistic/eslint-plugin-js": "1.5.1",
+				"@stylistic/eslint-plugin-jsx": "1.5.1",
+				"@stylistic/eslint-plugin-plus": "1.5.1",
+				"@stylistic/eslint-plugin-ts": "1.5.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.0.0.tgz",
-			"integrity": "sha512-xxvjyYnUEgjBTnXKYMk6JbU0LHkf269d6y4IgW69bK/VwHrqLfdgE6mYvft42U7KVpp6Tbf6Z64tLRYD/rYd/A==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.1.tgz",
+			"integrity": "sha512-iZF0rF+uOhAmOJYOJx1Yvmm3CZ1uz9n0SRd9dpBYHA3QAvfABUORh9LADWwZCigjHJkp2QbCZelGFJGwGz7Siw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"acorn": "^8.10.0",
+				"acorn": "^8.11.2",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esutils": "^2.0.3",
-				"graphemer": "^1.4.0"
+				"espree": "^9.6.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.0.0.tgz",
-			"integrity": "sha512-waUm7dcTFAI4d/3luf06RRNt89gSGaofHJ4BiuqKnpyu3yxn1lKbholjGQrw0xPjAciUe+ZSF6BKlBA9P2aV4Q==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.5.1.tgz",
+			"integrity": "sha512-JuX+jsbVdpZ6EZXkbxYr9ERcGc0ndSMFgOuwEPHhOWPZ+7F8JP/nzpBjrRf7dUPMX7ezTYLZ2a3KRGRNme6rWQ==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "^1.0.0",
-				"estraverse": "^5.3.0",
-				"jsx-ast-utils": "^3.3.5"
+				"@stylistic/eslint-plugin-js": "^1.5.1",
+				"estraverse": "^5.3.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
 			}
 		},
-		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.0.0.tgz",
-			"integrity": "sha512-qQKXYWJzovSNsPq1954t6DNbDA7+1c4ximVH4CuubPV+3I8qCeO33vF6wSpyP27LgxXAx0mHIDw/YaaoM7dQoQ==",
+		"node_modules/@stylistic/eslint-plugin-plus": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.5.1.tgz",
+			"integrity": "sha512-yxkFHsUgoqEf/j1Og0FGkpEmeQoqx0CMmtgoyZGr34hka0ElCy9fRpsFkLcwx60SfiHXspbvs2YUMXiWIffnjg==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.0.0",
-				"@typescript-eslint/scope-manager": "^6.8.0",
-				"@typescript-eslint/type-utils": "^6.8.0",
-				"@typescript-eslint/utils": "^6.8.0",
-				"graphemer": "^1.4.0"
+				"@typescript-eslint/utils": "^6.13.2"
 			},
 			"peerDependencies": {
 				"eslint": "*"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-ts": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.5.1.tgz",
+			"integrity": "sha512-oXM1V7Jp8G9+udxQTy+Igo79LR2e5HXiWqlA/3v+/PAqWxniR9nJqJSBjtQKJTPsGplDqn/ASpHUOETP4EI/4A==",
+			"dev": true,
+			"dependencies": {
+				"@stylistic/eslint-plugin-js": "1.5.1",
+				"@typescript-eslint/utils": "^6.13.2"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
 			}
 		},
 		"node_modules/@testing-library/dom": {
@@ -1927,9 +1951,9 @@
 			"dev": true
 		},
 		"node_modules/@testing-library/jest-dom": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.4.tgz",
-			"integrity": "sha512-wpoYrCYwSZ5/AxcrjLxJmCU6I5QAJXslEeSiMQqaWmP2Kzpd1LvF/qxmAIW2qposULGWq2gw30GgVNFLSc2Jnw==",
+			"version": "6.1.5",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.5.tgz",
+			"integrity": "sha512-3y04JLW+EceVPy2Em3VwNr95dOKqA8DhR0RJHhHKDZNYXcVXnEK7WIrpj4eYU8SVt/qYZ2aRWt/WgQ+grNES8g==",
 			"dev": true,
 			"dependencies": {
 				"@adobe/css-tools": "^4.3.1",
@@ -2154,9 +2178,9 @@
 			}
 		},
 		"node_modules/@types/express": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
-			"integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+			"integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/body-parser": "*",
@@ -2239,22 +2263,10 @@
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
 			"dev": true
 		},
-		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-			"dev": true
-		},
 		"node_modules/@types/node": {
 			"version": "20.4.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
 			"integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
-			"dev": true
-		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
 		"node_modules/@types/qs": {
@@ -2324,16 +2336,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
-			"integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
+			"integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/type-utils": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.14.0",
+				"@typescript-eslint/type-utils": "6.14.0",
+				"@typescript-eslint/utils": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2359,15 +2371,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
-			"integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
+			"integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.14.0",
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/typescript-estree": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2387,13 +2399,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-			"integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+			"integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0"
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2404,13 +2416,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
-			"integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
+			"integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.9.0",
-				"@typescript-eslint/utils": "6.9.0",
+				"@typescript-eslint/typescript-estree": "6.14.0",
+				"@typescript-eslint/utils": "6.14.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2431,9 +2443,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-			"integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+			"integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2444,13 +2456,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-			"integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+			"integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/visitor-keys": "6.9.0",
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2471,17 +2483,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
-			"integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
+			"integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.9.0",
-				"@typescript-eslint/types": "6.9.0",
-				"@typescript-eslint/typescript-estree": "6.9.0",
+				"@typescript-eslint/scope-manager": "6.14.0",
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/typescript-estree": "6.14.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2496,12 +2508,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-			"integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+			"integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.9.0",
+				"@typescript-eslint/types": "6.14.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2538,9 +2550,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2804,15 +2816,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/astral-regex": {
@@ -3151,36 +3154,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001555",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001555.tgz",
@@ -3440,21 +3413,29 @@
 			"dev": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 			"dev": true,
 			"dependencies": {
-				"import-fresh": "^3.2.1",
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0"
+				"parse-json": "^5.2.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/create-jest": {
@@ -3631,52 +3612,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decimal.js": {
@@ -3919,6 +3854,15 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4064,9 +4008,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.5.tgz",
-			"integrity": "sha512-bUxalY7b1g8vNhQKdB24QDmHeY4V4tw/s6Ak5z+jJX9laP5MoQseTOMemAr0gxssjNcH0MCViG8ONI2kksvfFQ==",
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.9.tgz",
+			"integrity": "sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -4076,28 +4020,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.19.5",
-				"@esbuild/android-arm64": "0.19.5",
-				"@esbuild/android-x64": "0.19.5",
-				"@esbuild/darwin-arm64": "0.19.5",
-				"@esbuild/darwin-x64": "0.19.5",
-				"@esbuild/freebsd-arm64": "0.19.5",
-				"@esbuild/freebsd-x64": "0.19.5",
-				"@esbuild/linux-arm": "0.19.5",
-				"@esbuild/linux-arm64": "0.19.5",
-				"@esbuild/linux-ia32": "0.19.5",
-				"@esbuild/linux-loong64": "0.19.5",
-				"@esbuild/linux-mips64el": "0.19.5",
-				"@esbuild/linux-ppc64": "0.19.5",
-				"@esbuild/linux-riscv64": "0.19.5",
-				"@esbuild/linux-s390x": "0.19.5",
-				"@esbuild/linux-x64": "0.19.5",
-				"@esbuild/netbsd-x64": "0.19.5",
-				"@esbuild/openbsd-x64": "0.19.5",
-				"@esbuild/sunos-x64": "0.19.5",
-				"@esbuild/win32-arm64": "0.19.5",
-				"@esbuild/win32-ia32": "0.19.5",
-				"@esbuild/win32-x64": "0.19.5"
+				"@esbuild/android-arm": "0.19.9",
+				"@esbuild/android-arm64": "0.19.9",
+				"@esbuild/android-x64": "0.19.9",
+				"@esbuild/darwin-arm64": "0.19.9",
+				"@esbuild/darwin-x64": "0.19.9",
+				"@esbuild/freebsd-arm64": "0.19.9",
+				"@esbuild/freebsd-x64": "0.19.9",
+				"@esbuild/linux-arm": "0.19.9",
+				"@esbuild/linux-arm64": "0.19.9",
+				"@esbuild/linux-ia32": "0.19.9",
+				"@esbuild/linux-loong64": "0.19.9",
+				"@esbuild/linux-mips64el": "0.19.9",
+				"@esbuild/linux-ppc64": "0.19.9",
+				"@esbuild/linux-riscv64": "0.19.9",
+				"@esbuild/linux-s390x": "0.19.9",
+				"@esbuild/linux-x64": "0.19.9",
+				"@esbuild/netbsd-x64": "0.19.9",
+				"@esbuild/openbsd-x64": "0.19.9",
+				"@esbuild/sunos-x64": "0.19.9",
+				"@esbuild/win32-arm64": "0.19.9",
+				"@esbuild/win32-ia32": "0.19.9",
+				"@esbuild/win32-x64": "0.19.9"
 			}
 		},
 		"node_modules/escalade": {
@@ -4149,15 +4093,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.52.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-			"integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.2",
-				"@eslint/js": "8.52.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -4657,9 +4601,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4797,9 +4741,9 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-			"integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
@@ -4807,7 +4751,7 @@
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -5016,9 +4960,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.21.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-			"integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -5094,15 +5038,6 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
-		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
@@ -5195,18 +5130,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -5304,9 +5227,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -5332,15 +5255,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/import-lazy": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/import-local": {
@@ -5369,18 +5283,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.19"
-			}
-		},
-		"node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -5676,15 +5578,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-plain-object": {
@@ -6780,27 +6673,15 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/marked": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.2.tgz",
-			"integrity": "sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-11.1.0.tgz",
+			"integrity": "sha512-fvKJWAPEafVj1dwGwcPI5mBB/0pvViL6NlCbNDG1HOIRwwAU/jeMoFxfbRLuirO1wRH7m4yPvBqD/O1wyWvayw==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/mathml-tag-names": {
@@ -6829,38 +6710,12 @@
 			}
 		},
 		"node_modules/meow": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
-			"dev": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=16.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6972,29 +6827,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/minimist-options/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7002,9 +6834,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"dev": true,
 			"funding": [
 				{
@@ -7045,21 +6877,6 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
 			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
-		},
-		"node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -7493,9 +7310,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"dev": true,
 			"funding": [
 				{
@@ -7512,7 +7329,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -7533,19 +7350,29 @@
 			"dev": true
 		},
 		"node_modules/postcss-safe-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+			"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"engines": {
-				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
+				"node": ">=18.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.3.3"
+				"postcss": "^8.4.31"
 			}
 		},
 		"node_modules/postcss-scss": {
@@ -7594,9 +7421,9 @@
 			"dev": true
 		},
 		"node_modules/preact": {
-			"version": "10.18.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.18.1.tgz",
-			"integrity": "sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==",
+			"version": "10.19.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+			"integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -7752,18 +7579,6 @@
 				}
 			]
 		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7794,65 +7609,6 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
-		"node_modules/read-pkg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-			"dev": true,
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^5.0.0",
-				"read-pkg": "^6.0.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7863,22 +7619,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/reflect.getprototypeof": {
@@ -8351,38 +8091,6 @@
 			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
 			"dev": true
 		},
-		"node_modules/spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"dev": true,
-			"dependencies": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-exceptions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-			"dev": true
-		},
-		"node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"dev": true,
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-license-ids": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-			"integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
-			"dev": true
-		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8552,21 +8260,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8579,54 +8272,46 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/style-search": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-			"dev": true
-		},
 		"node_modules/stylelint": {
-			"version": "15.11.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.11.0.tgz",
-			"integrity": "sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==",
+			"version": "16.0.2",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.0.2.tgz",
+			"integrity": "sha512-SxA/rg3VWxdoHZlW0nmVueWO1E7TAKW4W6mmA3iTxxEF9bIeQdFZu2oiBlQYyNe1pGnOamOqo2XYnI7cs5Bgow==",
 			"dev": true,
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^2.3.1",
-				"@csstools/css-tokenizer": "^2.2.0",
-				"@csstools/media-query-list-parser": "^2.1.4",
+				"@csstools/css-parser-algorithms": "^2.3.2",
+				"@csstools/css-tokenizer": "^2.2.1",
+				"@csstools/media-query-list-parser": "^2.1.5",
 				"@csstools/selector-specificity": "^3.0.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^8.2.0",
+				"cosmiconfig": "^9.0.0",
 				"css-functions-list": "^3.2.1",
 				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.3.1",
+				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^7.0.0",
+				"file-entry-cache": "^7.0.2",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^5.2.4",
-				"import-lazy": "^4.0.0",
+				"ignore": "^5.3.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
 				"known-css-properties": "^0.29.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^10.1.5",
+				"meow": "^12.1.1",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.28",
+				"postcss": "^8.4.32",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
+				"postcss-safe-parser": "^7.0.0",
 				"postcss-selector-parser": "^6.0.13",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
+				"strip-ansi": "^7.1.0",
 				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.8.1",
@@ -8636,7 +8321,7 @@
 				"stylelint": "bin/stylelint.mjs"
 			},
 			"engines": {
-				"node": "^14.13.1 || >=16.0.0"
+				"node": ">=18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -8644,30 +8329,33 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
-			"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
+			"integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
 			"dev": true,
 			"engines": {
-				"node": "^14.13.1 || >=16.0.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^15.10.0"
+				"stylelint": "^16.0.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended-scss": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.0.0.tgz",
-			"integrity": "sha512-7AmMIsHTsuwUQm7I+DD5BGeIgCvqYZ4BpeYJJpb1cUXQwrJAKjA+GBotFZgUEGP8lAM+wmd91ovzOi8xfAyWEw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.0.0.tgz",
+			"integrity": "sha512-HDvpoOAQ1RpF+sPbDOT2Q2/YrBDEJDnUymmVmZ7mMCeNiFSdhRdyGEimBkz06wsN+HaFwUh249gDR+I9JR7Onw==",
 			"dev": true,
 			"dependencies": {
-				"postcss-scss": "^4.0.7",
-				"stylelint-config-recommended": "^13.0.0",
-				"stylelint-scss": "^5.1.0"
+				"postcss-scss": "^4.0.9",
+				"stylelint-config-recommended": "^14.0.0",
+				"stylelint-scss": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.3.3",
-				"stylelint": "^15.10.0"
+				"stylelint": "^16.0.2"
 			},
 			"peerDependenciesMeta": {
 				"postcss": {
@@ -8676,26 +8364,35 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.2.1.tgz",
-			"integrity": "sha512-ZoTJUM85/qqpQHfEppjW/St//8s6p9Qsg8deWlYlr56F9iUgC9vXeIDQvH4odkRRJLTLFQzYMALSOFCQ3MDkgw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.0.0.tgz",
+			"integrity": "sha512-N1xV/Ef5PNRQQt9E45unzGvBUN1KZxCI8B4FgN/pMfmyRYbZGVN4y9qWlvOMdScU17c8VVCnjIHTVn38Bb6qSA==",
 			"dev": true,
 			"dependencies": {
-				"known-css-properties": "^0.28.0",
+				"known-css-properties": "^0.29.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-selector-parser": "^6.0.13",
 				"postcss-value-parser": "^4.2.0"
 			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
 			"peerDependencies": {
-				"stylelint": "^14.5.1 || ^15.0.0"
+				"stylelint": "^16.0.2"
 			}
 		},
-		"node_modules/stylelint-scss/node_modules/known-css-properties": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.28.0.tgz",
-			"integrity": "sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==",
-			"dev": true
+		"node_modules/stylelint/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
@@ -8704,12 +8401,12 @@
 			"dev": true
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.1.tgz",
-			"integrity": "sha512-uLfFktPmRetVCbHe5UPuekWrQ6hENufnA46qEGbfACkK5drjTTdQYUragRgMjHldcbYG+nslUerqMPjbBSHXjQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.2.tgz",
+			"integrity": "sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==",
 			"dev": true,
 			"dependencies": {
-				"flat-cache": "^3.1.1"
+				"flat-cache": "^3.2.0"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -8757,6 +8454,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/stylelint/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/stylelint/node_modules/which": {
@@ -8965,18 +8677,6 @@
 				"tree-kill": "cli.js"
 			}
 		},
-		"node_modules/trim-newlines": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -9042,9 +8742,9 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
@@ -9223,9 +8923,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -9350,16 +9050,6 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"dependencies": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/vary": {
@@ -9641,15 +9331,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/yargs/node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
 	"license": "Hippocratic-2.1",
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
-		"@stylistic/eslint-plugin": "^1.0.0",
-		"@testing-library/jest-dom": "^6.1.4",
+		"@stylistic/eslint-plugin": "^1.5.1",
+		"@testing-library/jest-dom": "^6.1.5",
 		"@testing-library/preact": "^3.2.3",
 		"@testing-library/user-event": "^14.5.1",
-		"@types/express": "^4.17.20",
-		"@typescript-eslint/eslint-plugin": "^6.9.0",
-		"@typescript-eslint/parser": "^6.9.0",
+		"@types/express": "^4.17.21",
+		"@typescript-eslint/eslint-plugin": "^6.14.0",
+		"@typescript-eslint/parser": "^6.14.0",
 		"concurrently": "^8.2.2",
 		"cross-env": "^7.0.3",
 		"dotenv": "^16.3.1",
-		"esbuild": "^0.19.5",
-		"eslint": "^8.52.0",
+		"esbuild": "^0.19.9",
+		"eslint": "^8.55.0",
 		"eslint-plugin-jest": "^27.6.0",
 		"eslint-plugin-react": "^7.33.2",
 		"eslint-plugin-react-hooks": "^4.6.0",
@@ -48,18 +48,18 @@
 		"jest-environment-jsdom": "^29.7.0",
 		"jsdom-testing-mocks": "^1.11.0",
 		"sass": "^1.69.5",
-		"stylelint": "^15.11.0",
-		"stylelint-config-recommended-scss": "^13.0.0",
+		"stylelint": "^16.0.2",
+		"stylelint-config-recommended-scss": "^14.0.0",
 		"ts-jest": "^29.1.1",
-		"ts-node": "^10.9.1",
-		"typescript": "^5.2.2"
+		"ts-node": "^10.9.2",
+		"typescript": "^5.3.3"
 	},
 	"engines": {
 		"node": ">=20"
 	},
 	"dependencies": {
-		"marked": "^9.1.2",
-		"preact": "^10.18.1",
+		"marked": "^11.1.0",
+		"preact": "^10.19.3",
 		"zod": "^3.22.4"
 	}
 }


### PR DESCRIPTION
This PR makes a few small config updates:

- Disable "no-console" linting rule in build scripts
- Fixed linting errors
- Tell vscode to use workspace version of TypeScript
- Updated dependencies, and accounted for a breaking change in `marked`