### PR TITLE
Move to custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Used by [Express](https://expressjs.com/) to determine which port to use when ru
 An example `.env` file you can use for development is:
 
 ```
-PROJECT_NAME = "orange-twist"
 MODE = "development"
 PORT = "8080"
 ```

--- a/app/404.html
+++ b/app/404.html
@@ -5,17 +5,17 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<!-- Favicon from [Twemoji](https://twemoji.twitter.com/) -->
-	<link rel="icon" href="/orange-twist/favicon.svg" />
+	<link rel="icon" href="/favicon.svg" />
 	<meta name="description" content="A todo app." />
 
-	<link rel="stylesheet" href="/orange-twist/assets/css/main.css" />
-	<link rel="preload" href="/orange-twist/assets/js/dist/priority.js" as="script" />
+	<link rel="stylesheet" href="/assets/css/main.css" />
+	<link rel="preload" href="/assets/js/dist/priority.js" as="script" />
 
-	<script type="module" src="/orange-twist/assets/js/dist/enhancements.js"></script>
-	<script type="module" src="/orange-twist/assets/js/dist/pages/404.js"></script>
+	<script type="module" src="/assets/js/dist/enhancements.js"></script>
+	<script type="module" src="/assets/js/dist/pages/404.js"></script>
 </head>
 <body>
-	<script type="text/javascript" src="/orange-twist/assets/js/dist/priority.js"></script>
+	<script type="text/javascript" src="/assets/js/dist/priority.js"></script>
 
 	<main id="main"></main>
 </body>

--- a/app/408.html
+++ b/app/408.html
@@ -5,17 +5,17 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<!-- Favicon from [Twemoji](https://twemoji.twitter.com/) -->
-	<link rel="icon" href="/orange-twist/favicon.svg" />
+	<link rel="icon" href="/favicon.svg" />
 	<meta name="description" content="A todo app." />
 
-	<link rel="stylesheet" href="/orange-twist/assets/css/main.css" />
-	<link rel="preload" href="/orange-twist/assets/js/dist/priority.js" as="script" />
+	<link rel="stylesheet" href="/assets/css/main.css" />
+	<link rel="preload" href="/assets/js/dist/priority.js" as="script" />
 
-	<script type="module" src="/orange-twist/assets/js/dist/enhancements.js"></script>
-	<script type="module" src="/orange-twist/assets/js/dist/pages/408.js"></script>
+	<script type="module" src="/assets/js/dist/enhancements.js"></script>
+	<script type="module" src="/assets/js/dist/pages/408.js"></script>
 </head>
 <body>
-	<script type="text/javascript" src="/orange-twist/assets/js/dist/priority.js"></script>
+	<script type="text/javascript" src="/assets/js/dist/priority.js"></script>
 
 	<main id="main"></main>
 </body>

--- a/app/assets/js/src/components/Task.tsx
+++ b/app/assets/js/src/components/Task.tsx
@@ -154,7 +154,7 @@ export function Task(props: TaskProps): JSX.Element | null {
 					dayName={dayName}
 				/>
 				<a
-					href={`/orange-twist/task/?id=${taskInfo.id}`}
+					href={`/task/?id=${taskInfo.id}`}
 					class="task__detail-link"
 					title="View task"
 				>📄</a>

--- a/app/assets/js/src/enhancements.ts
+++ b/app/assets/js/src/enhancements.ts
@@ -7,5 +7,5 @@
  */
 
 if (navigator.serviceWorker) {
-	navigator.serviceWorker.register('/orange-twist/service-worker.js');
+	navigator.serviceWorker.register('/service-worker.js');
 }

--- a/app/assets/js/src/service-worker/cache/populateCache.ts
+++ b/app/assets/js/src/service-worker/cache/populateCache.ts
@@ -7,8 +7,8 @@ export async function populateCache(): Promise<void> {
 	const cache = await caches.open(cacheName);
 
 	cache.addAll([
-		'/orange-twist/',
-		'/orange-twist/task/',
-		'/orange-twist/408.html',
+		'/',
+		'/task/',
+		'/408.html',
 	]);
 }

--- a/app/assets/js/src/service-worker/strategy/networkFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/networkFirst.ts
@@ -36,7 +36,7 @@ export async function networkFirst({ preloadResponse, request }: FetchEvent): Pr
 			// If the request is for a page, and we don't have a cached
 			// response, try to return a generic network error page
 			const errorResponse = await getCachedResponse(
-				new URL('/orange-twist/408.html', self.location.origin)
+				new URL('/408.html', self.location.origin)
 			);
 
 			if (errorResponse) {

--- a/app/index.html
+++ b/app/index.html
@@ -5,17 +5,17 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<!-- Favicon from [Twemoji](https://twemoji.twitter.com/) -->
-	<link rel="icon" href="/orange-twist/favicon.svg" />
+	<link rel="icon" href="/favicon.svg" />
 	<meta name="description" content="A todo app." />
 
-	<link rel="stylesheet" href="/orange-twist/assets/css/main.css" />
-	<link rel="preload" href="/orange-twist/assets/js/dist/priority.js" as="script" />
+	<link rel="stylesheet" href="/assets/css/main.css" />
+	<link rel="preload" href="/assets/js/dist/priority.js" as="script" />
 
-	<script type="module" src="/orange-twist/assets/js/dist/enhancements.js"></script>
-	<script type="module" src="/orange-twist/assets/js/dist/pages/main.js"></script>
+	<script type="module" src="/assets/js/dist/enhancements.js"></script>
+	<script type="module" src="/assets/js/dist/pages/main.js"></script>
 </head>
 <body>
-	<script type="text/javascript" src="/orange-twist/assets/js/dist/priority.js"></script>
+	<script type="text/javascript" src="/assets/js/dist/priority.js"></script>
 
 	<main id="main"></main>
 </body>

--- a/app/task/index.html
+++ b/app/task/index.html
@@ -5,17 +5,17 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<!-- Favicon from [Twemoji](https://twemoji.twitter.com/) -->
-	<link rel="icon" href="/orange-twist/favicon.svg" />
+	<link rel="icon" href="/favicon.svg" />
 	<meta name="description" content="A todo app." />
 
-	<link rel="stylesheet" href="/orange-twist/assets/css/main.css" />
-	<link rel="preload" href="/orange-twist/assets/js/dist/priority.js" as="script" />
+	<link rel="stylesheet" href="/assets/css/main.css" />
+	<link rel="preload" href="/assets/js/dist/priority.js" as="script" />
 
-	<script type="module" src="/orange-twist/assets/js/dist/enhancements.js"></script>
-	<script type="module" src="/orange-twist/assets/js/dist/pages/task.js"></script>
+	<script type="module" src="/assets/js/dist/enhancements.js"></script>
+	<script type="module" src="/assets/js/dist/pages/task.js"></script>
 </head>
 <body>
-	<script type="text/javascript" src="/orange-twist/assets/js/dist/priority.js"></script>
+	<script type="text/javascript" src="/assets/js/dist/priority.js"></script>
 
 	<main id="main"></main>
 </body>


### PR DESCRIPTION
I've moved where this project is hosted onto a custom domain. This PR removes references to the `/orange-twist/` path that was used when it was hosted on a GitHub Pages subdomain instead.