### PR TITLE
Updated workflow to run build and test on PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,7 +31,6 @@ jobs:
           name: 'build'
           path: './app'
 
-jobs:
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,7 +38,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     needs: build
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -22,42 +22,21 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install and build
+      - name: Build
         run: |
           npm ci
           npm run build
         env:
           MODE: production
 
+      - name: Test
+        run: npm test
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: 'build'
           path: './'
-
-  test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    needs: build
-
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: 'build'
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Rebuild
-        run: npm rebuild
-
-      - name: Test
-        run: npm test
 
   deploy:
     runs-on: ubuntu-latest
@@ -66,7 +45,7 @@ jobs:
       pages: write
       id-token: write
 
-    needs: [build, test]
+    needs: build-and-test
     if: github.ref == 'refs/heads/main'
 
     environment:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'build'
-          path: './app'
+          path: './'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Rebuild
+        run: npm rebuild
+
       - name: Test
         run: npm test
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,54 +4,80 @@ on:
     branches:
       - main
 jobs:
-  build-and-test:
-
+  build:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
 
-      - name: Install and Build
+      - name: Install and build
         run: |
-          npm install
+          npm ci
           npm run build
         env:
           MODE: production
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'build'
+          path: './app'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    needs: build
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: 'build'
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Test
         run: npm test
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: './app'
-
   deploy:
-    needs: build-and-test
-
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
-    runs-on: ubuntu-latest
+
+    needs: [build, test]
+    if: github.ref == 'refs/heads/main'
 
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: 'build'
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './app'
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ These dependencies are used for deploying the project to GitHub Pages.
 
 * [setup-node](https://github.com/marketplace/actions/setup-node-js-environment): Use to set up a Node.JS environment for the build and test scripts to run on during the deployment process.
 
+* [upload-artifact](https://github.com/marketplace/actions/upload-a-build-artifact): Used to upload a build artifact to be reused across multiple CI/CD jobs.
+
+* [download-artifact](https://github.com/marketplace/actions/download-artifact): Used to download a build artifact.
+
 * [upload-pages-artifact](https://github.com/marketplace/actions/upload-github-pages-artifact): Used to upload an artifact to use for deploying to GitHub Pages.
 
 * [deploy-pages](https://github.com/marketplace/actions/deploy-github-pages-site): Used to deploy the artifact to GitHub Pages.


### PR DESCRIPTION
In #47, I missed an introduced build error because the workflow to build and test the project only runs on new pushes to the `main` branch.

This PR updates the workflow so it should build and test on all PRs, as well as on pushes to `main`, and also deploys to GitHub Pages on pushes to `main`.