### PR TITLE
Change method of animating status component popover closed

### DIFF
--- a/app/assets/js/src/components/tasks/TaskStatusComponent/TaskStatusComponent.tsx
+++ b/app/assets/js/src/components/tasks/TaskStatusComponent/TaskStatusComponent.tsx
@@ -8,6 +8,8 @@ import {
 } from 'preact/hooks';
 
 import {
+	animate,
+	CSSKeyframes,
 	nodeHasAncestor,
 	useCloseWatcher,
 } from 'util/index';
@@ -174,18 +176,23 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 
 	// Show and hide the popover when we enter or leave change mode
 	useEffect(() => {
-		if (!canAnimateRef.current && isInChangeMode) {
+		if (!canAnimateRef.current) {
+			if (!isInChangeMode) {
+				return;
+			}
 			canAnimateRef.current = true;
 		}
 
-		if (!popoverRef.current) {
+		const popover = popoverRef.current;
+		if (!popover) {
 			return;
 		}
 
 		if (isInChangeMode) {
-			popoverRef.current.show();
+			popover.show();
 		} else {
-			popoverRef.current.close();
+			animate(popover, CSSKeyframes.DISAPPEAR_SCREEN)
+				.then(() => popover.close());
 		}
 	}, [isInChangeMode]);
 
@@ -247,7 +254,6 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 		<dialog
 			class="task-status__popover"
 			ref={popoverRef}
-			data-animate={canAnimateRef.current}
 			tabindex={-1}
 			inert={!isInChangeMode}
 		>

--- a/app/assets/js/src/util/CSSKeyframes.ts
+++ b/app/assets/js/src/util/CSSKeyframes.ts
@@ -1,7 +1,7 @@
 import type { EnumTypeOf } from './EnumTypeOf';
 
 /**
- * Names of CSS animations defined using `@keyframes` in `_animations.scss`.
+ * Names of CSS animations defined using `@keyframes` in `base/animation/_index.scss`.
  */
 export const CSSKeyframes = {
 	APPEAR_FADE: 'appearFade',

--- a/app/assets/scss/components/_task-status.scss
+++ b/app/assets/scss/components/_task-status.scss
@@ -18,20 +18,8 @@
 	margin-bottom: spacing.$sm;
 	z-index: 1;
 
-	&[data-animate] {
-		// Override the browser setting display: none, so we can animate out
-		display: grid;
-		&:not([open]) {
-			opacity: 0;
-			pointer-events: none;
-		}
-	}
-
 	&[open] {
 		animation: appearScreen animation.$speed-medium animation.$easing-default;
-	}
-	&:not([open]) {
-		animation: disappearScreen animation.$speed-medium animation.$easing-default;
 	}
 
 	// It's not interactive or tabbable, so let it have no focus style


### PR DESCRIPTION
The task status component was using `opacity: 0` and `pointer-events: none` to hide it while technically staying visible with `display: grid`, in order to enable animating out. However, this was causing visual bugs with the drag & drop image and with the reordering view transition.

This PR changes the way it animates out, so it becomes hidden properly once the closing animation finishes.

Resolves #55 