### PR TITLE
Reorder null fix

### DIFF
--- a/app/assets/js/src/components/tasks/TaskList.tsx
+++ b/app/assets/js/src/components/tasks/TaskList.tsx
@@ -154,9 +154,15 @@ export function TaskList(
 		isInDraggingMode.current = false;
 
 		// Construct a new order of tasks to send to `onReorder`
-		const newTasksOrder = itemsRef.current.map(
-			(element) => Number(element?.dataset.taskListItemId)
-		);
+		const newTasksOrder = itemsRef.current
+			// First, remove null entries
+			.filter(Boolean)
+			// Then, map to ID
+			.map(
+				(element) => {
+					return Number(element.dataset.taskListItemId);
+				}
+			);
 
 		// Determine the positions of the dragged element and drop targe
 		// to determine where to move the dragged element from and to

--- a/app/assets/scss/sub-components/_content.scss
+++ b/app/assets/scss/sub-components/_content.scss
@@ -74,6 +74,7 @@
 		display: inline-block;
 		@include palette.secondary;
 		@include typography.monospace-medium;
+		tab-size: 4;
 		// About enough to compensate for "`"
 		padding: 0 0.5ch;
 		border-radius: 0.2em;


### PR DESCRIPTION
Resolves #54 

This PR adds filtering logic so that reordering the tasks in a `<TaskList>` component after removing a task from it no longer causes a `NaN` task ID to be sent to the `onReorder` callback. Now, the argument sent to that callback should always properly reflect the current tasks being displayed.

Also, as a minor addition, this PR configures the `tab-size` rule for code blocks in notes.