### PR TITLE
Reset element's animation once `animate` is finished

### DIFF
--- a/app/assets/js/src/util/animate.ts
+++ b/app/assets/js/src/util/animate.ts
@@ -11,6 +11,7 @@ import { nextFrame } from './nextFrame';
  */
 export function animate(element: HTMLElement, keyframesName: CSSKeyframes): Promise<void> {
 	return new Promise((resolve) => {
+		const initialAnimationName = element.style.animationName;
 		element.style.animationName = keyframesName;
 		// TODO: Currently this relies on an element having an existing animation duration. We should set one if it's not already set
 		// Wait for the next frame to ensure the animation has been added
@@ -21,12 +22,16 @@ export function animate(element: HTMLElement, keyframesName: CSSKeyframes): Prom
 
 			// If there's no animation, resolve immediately
 			if (!newestAnimation) {
+				element.style.animationName = initialAnimationName;
 				resolve();
 				return;
 			}
 
 			// If there is an animation, resolve when it finishes
-			newestAnimation.finished.then(() => resolve());
+			newestAnimation.finished.then(() => {
+				element.style.animationName = initialAnimationName;
+				resolve();
+			});
 		});
 	});
 }


### PR DESCRIPTION
The `animate` utility function starts an animation on an element via JavaScript, by overriding its `animationName` CSS property. However, this function has not been reverting that property after the animation completed, which has resulted in the task status component showing its close animation when it is opened, after having previously been closed.

This PR fixes `animate` to revert this CSS property to its initial value after the animation is complete.

Resolves #62 