### PR TITLE
Build pipeline improvements

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm test
 
       - name: Upload build artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: 'build'


### PR DESCRIPTION
<!-- Describe the problem being solved -->
The build and test workflow has only been running against PRs to `main`, which doesn't match my new branching/merging strategy now that I'm trying to manage Orange Twist's version number. Also, the "upload artifact" step was running even if the deploy step that uses the artifact was never going to run.

<!-- Describe your solution -->
This PR updates the build and deploy pipeline to run against all PRs, and conditions the "upload artifact" step to only run for `main`.

<!-- List any issues that are resolved by this PR -->
Resolves #69 

<!-- Complete each item in this pre-merge checklist -->

_Skipping checklist because this PR contains no changes to Orange Twist_

- [ ] ~~The version number has been updated in `package.json`~~
- [ ] ~~The version number has been updated in `OrangeTwist.tsx`~~
- [ ] ~~A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)~~
