### PR TITLE
Static UI link styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-03-10
+
+### Fixed
+
+* Applied correct styling to links in footer and "first visit" UI
+
 ## [1.0.0] - 2024-02-23
 
 ### Added

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { h, type JSX } from 'preact';
  * Renders static footer content.
  */
 export function Footer(): JSX.Element {
-	return <footer class="orange-twist__footer">
+	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
 			<span class="orange-twist__footer-version">version 1.0.0</span>

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.0.0</span>
+			<span class="orange-twist__footer-version">version 1.0.1</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -23,7 +23,9 @@ export function DayList(): JSX.Element {
 		<h2 class="orange-twist__title">Days</h2>
 
 		{days.length <= 1 && (
-			<p>If you need help getting started, try <a href="/help">the help page</a>.</p>
+			<div class="content">
+				<p>If you need help getting started, try <a href="/help">the help page</a>.</p>
+			</div>
 		)}
 
 		{days.map((day, i) => (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
The links in the footer and "first visit" UI were using default browser styles.

<!-- Describe your solution -->
This PR applies standard "content" styling to these areas.

<!-- List any issues that are resolved by this PR -->
Resolves #81 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `OrangeTwist.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
