### PR TITLE
Don't show "first visit" UI during loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-03-10
+
+### Fixed
+
+* Applied correct font preload hints
+* Don't show "first visit" UI during loading
+
 ## [1.0.0] - 2024-02-23
 
 ### Added

--- a/app/404.html
+++ b/app/404.html
@@ -11,6 +11,8 @@
 
 	<link rel="preload" href="/assets/fonts/roboto/roboto-regular.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/nunito/nunito-bold.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/nunito/nunito-black.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/icons/icons.woff2" as="font" type="font/woff2" crossorigin>
 
 	<link rel="stylesheet" href="/assets/css/main.css">
 	<link rel="preload" href="/assets/js/dist/priority.js" as="script">

--- a/app/408.html
+++ b/app/408.html
@@ -11,6 +11,8 @@
 
 	<link rel="preload" href="/assets/fonts/roboto/roboto-regular.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/nunito/nunito-bold.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/nunito/nunito-black.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/icons/icons.woff2" as="font" type="font/woff2" crossorigin>
 
 	<link rel="stylesheet" href="/assets/css/main.css">
 	<link rel="preload" href="/assets/js/dist/priority.js" as="script">

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.0.0</span>
+			<span class="orange-twist__footer-version">version 1.0.1</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -1,11 +1,12 @@
 import { type JSX, h } from 'preact';
-import { useCallback, useMemo } from 'preact/hooks';
+import { useCallback, useContext, useMemo } from 'preact/hooks';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
 
 import { useAllDayInfo } from 'data';
 
+import { OrangeTwistContext } from '../OrangeTwistContext';
 import { Button } from '../shared';
 import { Day } from './Day';
 
@@ -15,6 +16,8 @@ import { Day } from './Day';
 export function DayList(): JSX.Element {
 	const unsortedDays = useAllDayInfo();
 
+	const { isLoading } = useContext(OrangeTwistContext);
+
 	const days = useMemo(() => unsortedDays.sort(
 		({ name: nameA }, { name: nameB }) => nameA.localeCompare(nameB)
 	), [unsortedDays]);
@@ -22,7 +25,7 @@ export function DayList(): JSX.Element {
 	return <section class="orange-twist__section">
 		<h2 class="orange-twist__title">Days</h2>
 
-		{days.length <= 1 && (
+		{!isLoading && days.length <= 1 && (
 			<p>If you need help getting started, try <a href="/help">the help page</a>.</p>
 		)}
 

--- a/app/help/index.html
+++ b/app/help/index.html
@@ -9,6 +9,7 @@
 	<meta name="description" content="Instructions for using Orange Twist, a web app for keeping track of notes and tasks.">
 
 	<link rel="preload" href="/assets/fonts/roboto/roboto-regular.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/nunito/nunito-bold.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/nunito/nunito-black.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/icons/icons.woff2" as="font" type="font/woff2" crossorigin>
 

--- a/app/index.html
+++ b/app/index.html
@@ -9,6 +9,7 @@
 	<meta name="description" content="A web app for keeping track of notes and tasks.">
 
 	<link rel="preload" href="/assets/fonts/roboto/roboto-regular.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/nunito/nunito-bold.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/nunito/nunito-black.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/icons/icons.woff2" as="font" type="font/woff2" crossorigin>
 

--- a/app/task/index.html
+++ b/app/task/index.html
@@ -9,6 +9,7 @@
 	<link rel="icon" href="/favicon.svg">
 
 	<link rel="preload" href="/assets/fonts/roboto/roboto-regular.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/assets/fonts/nunito/nunito-bold.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/nunito/nunito-black.woff2" as="font" type="font/woff2" crossorigin>
 	<link rel="preload" href="/assets/fonts/icons/icons.woff2" as="font" type="font/woff2" crossorigin>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
The "first visit" UI was showing during loading. Also, the font used on buttons was not showing initially.

<!-- Describe your solution -->
This PR makes the "first visit" UI only show once loading is complete, and updates the font preload hints.

<!-- List any issues that are resolved by this PR -->
Resolves #74 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `OrangeTwist.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
