### PR TITLE
Add eslint rule for formatting import statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -119,8 +119,9 @@ module.exports = {
 		'import-newlines/enforce': [
 			'warn',
 			{
-				'items': 2,
+				items: 2,
 				'max-len': 100,
+				forceSingleLine: false,
 			},
 		],
 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
 		'@typescript-eslint',
 		'react',
 		'react-hooks',
+		'import-newlines',
 	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -111,6 +112,17 @@ module.exports = {
 		// asynchronous, but which is planned to eventually become asynchronous, in order to provide
 		// a consistent interface
 		'@typescript-eslint/require-await': 'warn',
+
+		/////////////
+		// Plugins //
+		/////////////
+		'import-newlines/enforce': [
+			'warn',
+			{
+				'items': 2,
+				'max-len': 100,
+			},
+		],
 
 		////////////////////////
 		// Debugging warnings //

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ These dependencies are used when working on the project locally.
 
 	* [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): Provides Jest linting rules
 
+	* [eslint-plugin-import-newlines](https://www.npmjs.com/package/eslint-import-newlines): Provides a linting rule for named imports
+
 * [stylelint](https://www.npmjs.com/package/stylelint): Linting CSS
 
 	* [stylelint-config-recommended-scss](https://www.npmjs.com/package/stylelint-config-recommended-scss): Allows `stylelint` to lint SCSS files, and provides a base set of SCSS linting rules

--- a/app/assets/js/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/app/assets/js/src/components/CommandPalette/CommandPalette.test.tsx
@@ -9,7 +9,11 @@ import {
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { act, cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 
 import { CommandPalette } from './CommandPalette';
 import userEvent from '@testing-library/user-event';

--- a/app/assets/js/src/components/OrangeTwist.test.tsx
+++ b/app/assets/js/src/components/OrangeTwist.test.tsx
@@ -11,7 +11,11 @@ import {
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { act, cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { configMocks, mockAnimationsApi } from 'jsdom-testing-mocks';
 import { randomUUID } from 'node:crypto';

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -1,4 +1,8 @@
-import { h, type ComponentChildren, type JSX } from 'preact';
+import {
+	h,
+	type ComponentChildren,
+	type JSX,
+} from 'preact';
 import {
 	useCallback,
 	useEffect,
@@ -11,15 +15,12 @@ import {
 	loadDays,
 	saveDays,
 	setDayInfo,
-
 	createTask,
 	loadTasks,
 	saveTasks,
-
 	loadDayTasks,
 	saveDayTasks,
 	setDayTaskInfo,
-
 	exportData,
 	importData,
 } from 'data';

--- a/app/assets/js/src/components/ToolDrawer.tsx
+++ b/app/assets/js/src/components/ToolDrawer.tsx
@@ -2,8 +2,17 @@
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 import { type OrangeTwist } from './OrangeTwist';
 
-import { h, type ComponentChildren, type JSX } from 'preact';
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import {
+	h,
+	type ComponentChildren,
+	type JSX,
+} from 'preact';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'preact/hooks';
 
 import {
 	classNames,

--- a/app/assets/js/src/components/shared/Markdown.test.tsx
+++ b/app/assets/js/src/components/shared/Markdown.test.tsx
@@ -1,6 +1,12 @@
 import { h } from 'preact';
 
-import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import {
+	afterEach,
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
 import { cleanup, render } from '@testing-library/preact';

--- a/app/assets/js/src/components/shared/Modal.test.tsx
+++ b/app/assets/js/src/components/shared/Modal.test.tsx
@@ -1,9 +1,19 @@
 import { h } from 'preact';
 
-import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import {
+	afterEach,
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { act, cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 
 import { Modal } from './Modal';

--- a/app/assets/js/src/components/shared/Modal.tsx
+++ b/app/assets/js/src/components/shared/Modal.tsx
@@ -1,5 +1,13 @@
-import { h, type ComponentChildren, type JSX } from 'preact';
-import { useEffect, useLayoutEffect, useRef } from 'preact/hooks';
+import {
+	h,
+	type ComponentChildren,
+	type JSX,
+} from 'preact';
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+} from 'preact/hooks';
 
 import {
 	classNames,

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.test.tsx
@@ -12,7 +12,11 @@ import { cleanup, render } from '@testing-library/preact';
 import '@testing-library/jest-dom/jest-globals';
 
 import { TaskStatus } from 'types/TaskStatus';
-import { clear, createTask, setDayTaskInfo } from 'data';
+import {
+	clear,
+	createTask,
+	setDayTaskInfo,
+} from 'data';
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import { TaskDetail } from './TaskDetail';

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
@@ -1,5 +1,9 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useContext, useMemo } from 'preact/hooks';
+import {
+	useCallback,
+	useContext,
+	useMemo,
+} from 'preact/hooks';
 
 import { isValidDateString } from 'util/index';
 

--- a/app/assets/js/src/components/tasks/TaskStatusButton.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskStatusButton.test.tsx
@@ -11,7 +11,11 @@ import '@testing-library/jest-dom/jest-globals';
 import { render } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 
-import { TaskStatus, TaskStatusName, TaskStatusSymbol } from 'types/TaskStatus';
+import {
+	TaskStatus,
+	TaskStatusName,
+	TaskStatusSymbol,
+} from 'types/TaskStatus';
 
 import { TaskStatusButton } from './TaskStatusComponent/TaskStatusButton';
 

--- a/app/assets/js/src/data/dayTasks/hooks/useAllDayTaskInfo.ts
+++ b/app/assets/js/src/data/dayTasks/hooks/useAllDayTaskInfo.ts
@@ -1,4 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'preact/hooks';
 
 import {
 	type DayTaskIdentifier,

--- a/app/assets/js/src/data/dayTasks/hooks/useDayTaskInfo.ts
+++ b/app/assets/js/src/data/dayTasks/hooks/useDayTaskInfo.ts
@@ -1,4 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'preact/hooks';
 
 import {
 	type DayTaskIdentifier,

--- a/app/assets/js/src/data/dayTasks/persistence/updateOldDayTaskInfo.test.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/updateOldDayTaskInfo.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from '@jest/globals';
+import {
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
 
 import { TaskStatus } from 'types/TaskStatus';
 

--- a/app/assets/js/src/data/days/persistence/updateOldDayInfo.test.ts
+++ b/app/assets/js/src/data/days/persistence/updateOldDayInfo.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from '@jest/globals';
+import {
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
 
 import { updateOldDayInfo } from './updateOldDayInfo';
 

--- a/app/assets/js/src/data/days/setDayInfo.ts
+++ b/app/assets/js/src/data/days/setDayInfo.ts
@@ -3,7 +3,11 @@ import type { DayInfo } from './types';
 import { isValidDateString } from 'util/index';
 
 import { daysRegister } from './daysRegister';
-import { getDayTaskInfo, setDayTaskInfo, type DayTaskInfo } from '../dayTasks';
+import {
+	getDayTaskInfo,
+	setDayTaskInfo,
+	type DayTaskInfo,
+} from '../dayTasks';
 import { getTaskStatusForDay } from '../shared';
 
 const defaultDayInfo = {

--- a/app/assets/js/src/data/tasks/setAllTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/setAllTaskInfo.test.ts
@@ -9,7 +9,12 @@ import {
 import { tasksRegister } from './tasksRegister';
 
 import { setAllTaskInfo } from './setAllTaskInfo';
-import { clear, getAllTaskInfo, getTaskInfo, setTaskInfo } from 'data';
+import {
+	clear,
+	getAllTaskInfo,
+	getTaskInfo,
+	setTaskInfo,
+} from 'data';
 import { TaskStatus } from 'types/TaskStatus';
 
 describe('setAllTaskInfo', () => {

--- a/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
+++ b/app/assets/js/src/data/tasks/updateOldTaskInfo.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from '@jest/globals';
+import {
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
 
 import { TaskStatus } from 'types/TaskStatus';
 

--- a/app/assets/js/src/registers/commands/hooks/useCommandInfo.ts
+++ b/app/assets/js/src/registers/commands/hooks/useCommandInfo.ts
@@ -1,4 +1,8 @@
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useState,
+} from 'preact/hooks';
 
 import type { CommandInfo } from '../types/CommandInfo';
 import type { CommandId } from '../types/CommandId';

--- a/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/hooks/useKeyboardShortcut.ts
@@ -1,9 +1,8 @@
-import type {
-	CommandId,
-	// Type-only import to make symbol available to JSDoc
-	/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-	useCommand,
-} from 'registers/commands';
+// Type-only import to make symbol available to JSDoc
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+import type { useCommand } from 'registers/commands';
+
+import type { CommandId } from 'registers/commands';
 
 import { useEffect } from 'preact/hooks';
 

--- a/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.test.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/listeners/addKeyboardShortcutListener.test.ts
@@ -12,7 +12,10 @@ import { KeyboardShortcutName } from '../types/KeyboardShortcutName';
 import { registerKeyboardShortcut } from '../registerKeyboardShortcut';
 import { getKeyboardShortcut } from '../getKeyboardShortcut';
 
-import { addKeyboardShortcutListener, removeKeyboardShortcutListener } from './addKeyboardShortcutListener';
+import {
+	addKeyboardShortcutListener,
+	removeKeyboardShortcutListener,
+} from './addKeyboardShortcutListener';
 
 beforeAll(() => {
 	registerKeyboardShortcut(KeyboardShortcutName.DATA_SAVE, [{ key: 'a' }]);

--- a/app/assets/js/src/registers/keyboard-shortcuts/listeners/bindKeyboardShortcutToCommand.test.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/listeners/bindKeyboardShortcutToCommand.test.ts
@@ -17,7 +17,10 @@ import {
 	unregisterCommand,
 } from 'registers/commands';
 
-import { bindKeyboardShortcutToCommand, unbindKeyboardShortcutFromCommand } from './bindKeyboardShortcutToCommand';
+import {
+	bindKeyboardShortcutToCommand,
+	unbindKeyboardShortcutFromCommand,
+} from './bindKeyboardShortcutToCommand';
 import userEvent from '@testing-library/user-event';
 
 describe('bindKeyboardShortcutToCommand', () => {

--- a/app/assets/js/src/registers/keyboard-shortcuts/listeners/bindKeyboardShortcutToCommand.ts
+++ b/app/assets/js/src/registers/keyboard-shortcuts/listeners/bindKeyboardShortcutToCommand.ts
@@ -5,7 +5,10 @@ import {
 import { fireCommand } from '../../commands';
 
 import { KeyboardShortcutName } from '../types/KeyboardShortcutName';
-import { addKeyboardShortcutListener, removeKeyboardShortcutListener } from './addKeyboardShortcutListener';
+import {
+	addKeyboardShortcutListener,
+	removeKeyboardShortcutListener,
+} from './addKeyboardShortcutListener';
 
 /**
  * Functions that can be used to fire commands.

--- a/app/assets/js/src/ui/alert/Toast.tsx
+++ b/app/assets/js/src/ui/alert/Toast.tsx
@@ -1,5 +1,9 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useEffect, useRef } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+} from 'preact/hooks';
 
 import { animate, CSSKeyframes } from 'util/index';
 import { removeToast, renderToasts } from './toast-controller';

--- a/app/assets/js/src/util/isZodSchemaType.test.ts
+++ b/app/assets/js/src/util/isZodSchemaType.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from '@jest/globals';
+import {
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
 
 import { z } from 'zod';
 

--- a/app/assets/js/src/util/useViewTransition.ts
+++ b/app/assets/js/src/util/useViewTransition.ts
@@ -1,4 +1,8 @@
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useState,
+} from 'preact/hooks';
 
 interface ViewTransitionState {
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"dotenv": "^16.3.1",
 				"esbuild": "^0.19.9",
 				"eslint": "^8.55.0",
+				"eslint-plugin-import-newlines": "^1.3.4",
 				"eslint-plugin-jest": "^27.6.0",
 				"eslint-plugin-react": "^7.33.2",
 				"eslint-plugin-react-hooks": "^4.6.0",
@@ -4147,6 +4148,21 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-import-newlines": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import-newlines/-/eslint-plugin-import-newlines-1.3.4.tgz",
+			"integrity": "sha512-Lmf/BbK+EQKUfjKPcZpslE/KTGYlgaI8ZJ/sYzdbb3BVTg5+GmLBLHBjsUKNEVRM1SEhDTF/didtOSYKi4tSnQ==",
+			"dev": true,
+			"bin": {
+				"import-linter": "lib/index.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-jest": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"dotenv": "^16.3.1",
 		"esbuild": "^0.19.9",
 		"eslint": "^8.55.0",
+		"eslint-plugin-import-newlines": "^1.3.4",
 		"eslint-plugin-jest": "^27.6.0",
 		"eslint-plugin-react": "^7.33.2",
 		"eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
For some time, I've wanted to be able to add a linting rule to automatically handle the formatting of my `import` statements. VS Code tends to automatically insert new imports onto the same line by default, but once import lines become long enough I prefer to split them over multiple lines.

<!-- Describe your solution -->
This PR adds [the `import-newlines` eslint plugin](https://www.npmjs.com/package/eslint-plugin-import-newlines), and applies its autofix.

<!-- Complete each item in this pre-merge checklist -->

_Skipping version checklist because this PR doesn't include any functional changes._

- [ ] ~~The version number has been updated in `package.json`~~
- [ ] ~~The version number has been updated in `Footer.tsx`~~
- [ ] ~~A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)~~
