### PR TITLE
Scroll to first open day after initial loading is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - 2024-03-10
+## [1.1.0] - 2024-03-10
+
+### Added
+
+* Main view scrolls to current day automatically
 
 ### Fixed
 

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.0.2</span>
+			<span class="orange-twist__footer-version">version 1.1.0</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -6,6 +6,7 @@ import {
 import {
 	useCallback,
 	useEffect,
+	useRef,
 	useState,
 } from 'preact/hooks';
 
@@ -106,6 +107,24 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 	}, [
 		loadAllData,
 	]);
+
+	// Scroll to first open day when initial loading is complete
+	const hasDoneInitialScroll = useRef(false);
+	useEffect(() => {
+		if (hasDoneInitialScroll.current) {
+			return;
+		}
+
+		if (!isLoading) {
+			const firstOpenDay = document.querySelector('.js-day[open]');
+			if (firstOpenDay) {
+				firstOpenDay.scrollIntoView({
+					behavior: 'instant',
+				});
+			}
+			hasDoneInitialScroll.current = true;
+		}
+	}, [isLoading]);
 
 	// Load persisted data when serialised data
 	// is updated from another source

--- a/app/assets/js/src/components/days/Day.tsx
+++ b/app/assets/js/src/components/days/Day.tsx
@@ -56,7 +56,7 @@ export const Day = (props: DayProps): JSX.Element => {
 	}, [name]);
 
 	return <details
-		class="day"
+		class="day js-day"
 		{...passthroughProps}
 	>
 		<summary class="day__summary">

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -1,5 +1,9 @@
 import { type JSX, h } from 'preact';
-import { useCallback, useContext, useMemo } from 'preact/hooks';
+import {
+	useCallback,
+	useContext,
+	useMemo,
+} from 'preact/hooks';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When loading the main view, the initial scroll position being at the top of the page means there can be a lot of content to scroll down through to get to the current day. But scrolling to the very bottom might still mean there are a lot of tasks to scroll up through.

<!-- Describe your solution -->
This PR sets up the main view to scroll to the first open day immediately after the initial loading is complete.

<!-- List any issues that are resolved by this PR -->
Resolves #70 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
