### PR TITLE
Fix multi-page editing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* Resolved random sync failures in multi-tab editing caused by browser race condition
 * Applied correct font preload hints
 * Don't show "first visit" UI during loading
 * The current day expands by default, even if future days exist

--- a/app/assets/js/src/sync/LocalStorageKey.ts
+++ b/app/assets/js/src/sync/LocalStorageKey.ts
@@ -1,0 +1,3 @@
+export const LocalStorageKey = {
+	UPDATE_NUMBER: 'update-number',
+} as const;

--- a/app/assets/js/src/sync/channel.ts
+++ b/app/assets/js/src/sync/channel.ts
@@ -1,21 +1,40 @@
+import { LocalStorageKey } from './localStorageKey';
 import { MessageType, isMessage } from './types';
 
 export const syncCallbacks = new Set<() => void>();
 
 export const channel = new BroadcastChannel('orange-twist');
 
+/**
+ * Execute each sync callback in order.
+ */
+function callSyncCallbacks() {
+	const callbacks = syncCallbacks.values();
+	for (const callback of callbacks) {
+		callback();
+	}
+}
+
 // Add a listener for "sync update" events firing in other contexts.
 channel.addEventListener(
 	'message',
-	({ data }) => {
-		if (!isMessage(data)) {
+	({ data: message }) => {
+		if (!isMessage(message)) {
 			return;
 		}
 
-		if (data.type === MessageType.SYNC_UPDATE) {
-			const callbacks = syncCallbacks.values();
-			for (const callback of callbacks) {
-				callback();
+		if (message.type === MessageType.SYNC_UPDATE) {
+			const updateNumber = localStorage.getItem(
+				LocalStorageKey.UPDATE_NUMBER
+			);
+			if (updateNumber === message.data) {
+				callSyncCallbacks();
+			} else {
+				window.addEventListener(
+					'storage',
+					callSyncCallbacks,
+					{ once: true }
+				);
 			}
 		}
 	}

--- a/app/assets/js/src/sync/channel.ts
+++ b/app/assets/js/src/sync/channel.ts
@@ -1,4 +1,4 @@
-import { LocalStorageKey } from './localStorageKey';
+import { LocalStorageKey } from './LocalStorageKey';
 import { MessageType, isMessage } from './types';
 
 export const syncCallbacks = new Set<() => void>();

--- a/app/assets/js/src/sync/channel.ts
+++ b/app/assets/js/src/sync/channel.ts
@@ -1,5 +1,7 @@
-import { LocalStorageKey } from './LocalStorageKey';
+import { assertAllUnionMembersHandled } from 'util/index';
+
 import { MessageType, isMessage } from './types';
+import { LocalStorageKey } from './LocalStorageKey';
 
 export const syncCallbacks = new Set<() => void>();
 
@@ -36,6 +38,8 @@ channel.addEventListener(
 					{ once: true }
 				);
 			}
+		} else {
+			assertAllUnionMembersHandled(message.type);
 		}
 	}
 );

--- a/app/assets/js/src/sync/postMessage.ts
+++ b/app/assets/js/src/sync/postMessage.ts
@@ -1,5 +1,5 @@
 import { channel } from './channel';
-import { LocalStorageKey } from './localStorageKey';
+import { LocalStorageKey } from './LocalStorageKey';
 import { MessageType, type Message } from './types';
 
 export function postMessage(message: Message): void {

--- a/app/assets/js/src/sync/postMessage.ts
+++ b/app/assets/js/src/sync/postMessage.ts
@@ -1,6 +1,13 @@
 import { channel } from './channel';
-import type { Message } from './types';
+import { LocalStorageKey } from './localStorageKey';
+import { MessageType, type Message } from './types';
 
 export function postMessage(message: Message): void {
+	if (message.type === MessageType.SYNC_UPDATE) {
+		localStorage.setItem(
+			LocalStorageKey.UPDATE_NUMBER,
+			message.data,
+		);
+	}
 	channel.postMessage(message);
 }

--- a/app/assets/js/src/sync/syncUpdate.ts
+++ b/app/assets/js/src/sync/syncUpdate.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { onSyncUpdate } from './onSyncUpdate';
 
-import { LocalStorageKey } from './localStorageKey';
+import { LocalStorageKey } from './LocalStorageKey';
 
 import { postMessage } from './postMessage';
 import { MessageType } from './types';

--- a/app/assets/js/src/sync/syncUpdate.ts
+++ b/app/assets/js/src/sync/syncUpdate.ts
@@ -2,15 +2,23 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { onSyncUpdate } from './onSyncUpdate';
 
+import { LocalStorageKey } from './localStorageKey';
+
 import { postMessage } from './postMessage';
 import { MessageType } from './types';
+
+let updateNumber = Number(
+	localStorage.getItem(LocalStorageKey.UPDATE_NUMBER)
+) || 0;
 
 /**
  * Fires all listeners bound with {@linkcode onSyncUpdate} in other
  * contexts, such as other browser tabs.
  */
 export function syncUpdate(): void {
+	updateNumber += 1;
 	postMessage({
 		type: MessageType.SYNC_UPDATE,
+		data: String(updateNumber),
 	});
 }

--- a/app/assets/js/src/sync/types/message.ts
+++ b/app/assets/js/src/sync/types/message.ts
@@ -7,9 +7,16 @@ export const MessageType = {
 } as const;
 export type MessageType = EnumTypeOf<typeof MessageType>;
 
-const messageSchema = z.object({
+const baseMessageSchema = z.object({
 	type: z.nativeEnum(MessageType),
 });
+
+const syncUpdateMessageSchema = baseMessageSchema.extend({
+	data: z.string(),
+});
+
+const messageSchema = syncUpdateMessageSchema;
+
 export type Message = z.infer<typeof messageSchema>;
 
 export const isMessage = isZodSchemaType(messageSchema);


### PR DESCRIPTION
<!-- Describe the problem being solved -->
It turns out web browsers (or at least Chrome) have a race condition between `localStorage` changes being available in new contexts, and `BroadcastChannel` messages arriving. This has caused multi-tab editing to randomly fail when other contexts read stale data.

<!-- Describe your solution -->
This PR updates the syncing code to also send a signal that it compares with `localStorage` data. If the signal values match, it calls sync callbacks immediately. Otherwise, it waits for the next `storage` event to arrive.

<!-- List any issues that are resolved by this PR -->
Resolves #76 

<!-- Complete each item in this pre-merge checklist -->

_Version number already updated for a fix in `next`_, so this PR only updates the changelog.

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
