### PR TITLE
Fix inline code size inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 * Tool drawer toggle buttons use a pointer cursor
+* Inline code in task names won't appear small on task detail page
 
 ## [1.1.0] - 2024-03-10
 

--- a/app/assets/scss/sub-components/_content.scss
+++ b/app/assets/scss/sub-components/_content.scss
@@ -80,7 +80,7 @@
 	code {
 		display: inline-block;
 		@include palette.secondary;
-		@include typography.monospace-medium;
+		@include typography.monospace-inherit;
 		tab-size: 4;
 		// About enough to compensate for "`"
 		padding: 0 0.5ch;

--- a/app/assets/scss/theme/_typography.scss
+++ b/app/assets/scss/theme/_typography.scss
@@ -99,6 +99,12 @@ $_line-height-monospace: 1.4;
 	@include _font-size(rem(18px), $_line-height-monospace);
 }
 
+@mixin monospace-inherit {
+	font-family: $family-monospace;
+	font-weight: $weight-monospace;
+	@include _font-size(1em, $_line-height-monospace);
+}
+
 ///////////
 // Icons //
 ///////////


### PR DESCRIPTION
<!-- Describe the problem being solved -->

Inline code didn't inherit its font size from its context (e.g. in a heading).

<!-- Describe your solution -->

This PR adds a new mixin for monospace text that inherits its font size, and uses it in inline code.

<!-- List any issues that are resolved by this PR -->
Resolves #101 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
