### PR TITLE
Build artifact size reduction

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'build'
-          path: './'
+          path: './app'
 
   deploy:
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './app'
+          path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
<!-- Describe the problem being solved -->

When the build and deploy workflow runs, the build artifact that gets updated includes the entire project directory. But when the build artifact is downloaded and used, only the `app` folder is used. This means we're uploading and extracting `node_modules` each time for no benefit.

<!-- Describe your solution -->

This PR only uploads the `app` folder for the build artifact, then uses the whole thing for the deploy step.

Unfortunately there's no real way I can test this change until it's deployed to prod.

<!-- List any issues that are resolved by this PR -->
Resolves #92

<!-- Complete each item in this pre-merge checklist -->

_Skipping version update checklist because this only affects the build process_

- [ ] ~~The version number has been updated in `package.json`~~
- [ ] ~~The version number has been updated in `Footer.tsx`~~
- [ ] ~~A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)~~
