### PR TITLE
Fix spacing in inline note with multiple children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2024-03-15
+
+### Fixed
+
+* Fixed collapsed space between formatted parts of task names
+
 ## [1.2.1] - 2024-03-14
 
 ### Fixed

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.2.1</span>
+			<span class="orange-twist__footer-version">version 1.2.2</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/scss/components/_inline-note.scss
+++ b/app/assets/scss/components/_inline-note.scss
@@ -36,8 +36,6 @@
 }
 
 .inline-note__display {
-	display: flex;
-	align-items: center;
 	overflow: hidden;
 	p {
 		white-space: pre;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
After recent changes, inline note components (used for displaying task names in task lists) have started collapsing the space between different elements, e.g. if a name contains a link or an inline code block.

<!-- Describe your solution -->
This PR changes the styling of inline note content so it no longer uses flexbox, allowing whitespace to display as expected.

<!-- List any issues that are resolved by this PR -->
Resolves #107

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
