### PR TITLE
Scroll to today in task detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2024-03-15
+
+### Added
+
+* Task detail view scrolls to current day automatically
+
 ## [1.2.1] - 2024-03-14
 
 ### Fixed

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.2.1</span>
+			<span class="orange-twist__footer-version">version 1.3.0</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
@@ -35,7 +35,7 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 
 	return <details
 		key={dayName}
-		class="day"
+		class="day js-day"
 		open={open}
 	>
 		<summary class="day__summary">

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
@@ -5,7 +5,7 @@ import {
 	useMemo,
 } from 'preact/hooks';
 
-import { isValidDateString } from 'utils';
+import { getCurrentDateDayName, isValidDateString } from 'utils';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
@@ -83,6 +83,25 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 		fireCommand(Command.DATA_SAVE);
 	}, [taskId]);
 
+	const currentDayName = getCurrentDateDayName();
+
+	const expandedDayTaskIndex = useMemo(
+		() => {
+			// If the day tasks list includes the current day, expand it
+			const currentDayIndex = dayTasksInfo.findIndex(
+				({ dayName }) => dayName === currentDayName
+			);
+
+			if (currentDayIndex !== -1) {
+				return currentDayIndex;
+			}
+
+			// Otherwise, expand the last day task
+			return dayTasksInfo.length - 1;
+		},
+		[dayTasksInfo, currentDayName]
+	);
+
 	if (isLoading) {
 		return <Loader />;
 	}
@@ -108,7 +127,7 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 			<DayTaskDetail
 				key={dayTaskInfo.dayName}
 				dayTaskInfo={dayTaskInfo}
-				open={i === arr.length-1}
+				open={i === expandedDayTaskIndex}
 			/>
 		))}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When opening a task detail page, sometimes it might have future days already. But if it has data for the current day, that should expand instead.

<!-- Describe your solution -->
This PR makes the current day expanded by default, if it's there. Otherwise, the last day will expand. Also, the page will automatically scroll to the first open day just like in the main view.

<!-- List any issues that are resolved by this PR -->
Resolves #96 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
