### PR TITLE
Use a date input for adding a new day

### DIFF
--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -291,7 +291,7 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 		const days = getAllDayInfo();
 
 		const dayName = dayNameArg ?? await ui.prompt('What day?', {
-			placeholder: 'YYYY-MM-DD',
+			type: 'date',
 		});
 		if (!dayName) {
 			return;

--- a/app/assets/js/src/ui/prompt/ModalPrompt.tsx
+++ b/app/assets/js/src/ui/prompt/ModalPrompt.tsx
@@ -15,6 +15,8 @@ import {
 interface ModalPromptProps {
 	message: string;
 	placeholder?: string;
+	/** @default 'text' */
+	type?: string;
 	resolve: (result: string | null) => void;
 }
 
@@ -27,6 +29,7 @@ export function ModalPrompt(props: ModalPromptProps): JSX.Element {
 	const {
 		message,
 		placeholder,
+		type,
 		resolve,
 	} = props;
 
@@ -78,7 +81,7 @@ export function ModalPrompt(props: ModalPromptProps): JSX.Element {
 			<label>
 				<div class="modal-prompt__message">{message}</div>
 				<input
-					type="text"
+					type={type ?? 'text'}
 					name="result"
 					class="modal-prompt__input"
 					placeholder={placeholder}

--- a/app/assets/js/src/ui/prompt/prompt.tsx
+++ b/app/assets/js/src/ui/prompt/prompt.tsx
@@ -9,6 +9,8 @@ document.body.append(promptContainer);
 
 interface PromptOptions {
 	placeholder?: string;
+	/** @default 'text' */
+	type?: string;
 }
 
 /**
@@ -25,6 +27,7 @@ export async function prompt(
 	render(<ModalPrompt
 		message={message}
 		placeholder={options?.placeholder}
+		type={options?.type ?? 'text'}
 		resolve={resolve}
 	/>, promptContainer);
 


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Adding a new day requires manually typing a correctly formatted date string.

<!-- Describe your solution -->
This PR makes the "Add new day" form use a date input instead.

<!-- List any issues that are resolved by this PR -->
Resolves #115

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
