### PR TITLE
Fix toast progress animation by adding a fallback

### DIFF
--- a/app/assets/js/src/ui/alert/Toast.tsx
+++ b/app/assets/js/src/ui/alert/Toast.tsx
@@ -40,17 +40,20 @@ export function Toast(props: ToastProps): JSX.Element {
 
 	// After the initial render, start the animation
 	useEffect(() => {
+		const progressEl = progressRef.current;
+
 		if (
 			duration &&
-			progressRef.current &&
+			progressEl &&
 			!progressAnimationRef.current
 		) {
-			progressAnimationRef.current = progressRef.current.animate([
+			progressAnimationRef.current = progressEl.animate([
 				{ width: 0 },
 				{ width: '100%' },
 			], { duration });
 
 			progressAnimationRef.current.finished.then(async () => {
+				progressEl.style.width = '100%';
 				if (toastRef.current) {
 					// TODO: If a toast with the same ID is updated while it's animating out, it won't re-show
 					const animation = animate(toastRef.current, CSSKeyframes.DISAPPEAR_UP);

--- a/app/assets/scss/sub-components/_toast.scss
+++ b/app/assets/scss/sub-components/_toast.scss
@@ -32,7 +32,19 @@
 .toast__progress {
 	// Start at width 0 so there's no 1 frame flash after rendering
 	width: 0;
-	background-color: rgb(from var(--colour) r g b / 0.1);
+	@supports (background-color: rgb(from white r g b / 0.1)) {
+		background-color: rgb(from var(--colour) r g b / 0.1);
+	}
+	@supports not (background-color: rgb(from white r g b / 0.1)) {
+		position: relative;
+		&::before {
+			content: "";
+			position: absolute;
+			inset: 0;
+			background-color: var(--colour);
+			opacity: 0.1;
+		}
+	}
 	pointer-events: none;
 }
 


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Firefox doesn't support CSS relative colour syntax, which the toast progress animation uses.

<!-- Describe your solution -->
This PR adds a fallback for browsers that don't support CSS relative colour syntax.

<!-- List any issues that are resolved by this PR -->
Resolves #121

<!-- Complete each item in this pre-merge checklist -->

- [ ] The version number has been updated in `package.json`
- [ ] The version number has been updated in `Footer.tsx`
- [ ] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
