### PR TITLE
Save template name changes at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2024-04-13
+
+### Fixed
+
+* Editing a template name no longer causes the "Saved" message to show on every character typed
+
 ## [1.4.0] - 2024-04-13
 
 ### Fixed

--- a/app/assets/js/src/components/Footer.tsx
+++ b/app/assets/js/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer(): JSX.Element {
 	return <footer class="orange-twist__footer content">
 		<div class="orange-twist__footer-row">
 			<span class="orange-twist__footer-version">by Mark Hanna</span>
-			<span class="orange-twist__footer-version">version 1.4.0</span>
+			<span class="orange-twist__footer-version">version 1.4.1</span>
 		</div>
 		<div class="orange-twist__footer-row">
 			<a href="/help/">

--- a/app/assets/js/src/components/templates/Template.tsx
+++ b/app/assets/js/src/components/templates/Template.tsx
@@ -60,7 +60,6 @@ export function Template(props: TemplateProps): JSX.Element | null {
 
 		const name = newName ?? '';
 		setTemplateInfo(templateInfo.id, { name });
-		fireCommand(Command.DATA_SAVE);
 	}, [templateInfo]);
 
 	const definitionChangeHandler = useCallback<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->

When editing a template name, "Saved" shows as a toast on each character typed.

<!-- Describe your solution -->

This PR removes the save command that was fired while editing a template name. The one that fires when the name change is completed is still there.

<!-- List any issues that are resolved by this PR -->
Resolves #131

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] The version number has been updated in `Footer.tsx`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
