### PR TITLE
Persist API and LocalStorage adapter

### DIFF
--- a/app/assets/js/src/data/dayTasks/persistence/saveDayTasks.test.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/saveDayTasks.test.ts
@@ -38,18 +38,14 @@ describe('saveDayTasks', () => {
 	});
 
 	test('returns a Promise that resolves when the content of the day tasks register has been persisted', async () => {
+		expect(localStorage.getItem('day-tasks')).toBeNull();
+
 		setDayTaskInfo({ dayName: '2023-11-13', taskId: 1 }, firstDayTaskInfo);
 		setDayTaskInfo({ dayName: '2023-11-13', taskId: 2 }, secondDayTaskInfo);
 
-		expect(localStorage.getItem('day-tasks')).toBeNull();
-
 		const saveDayTasksPromise = saveDayTasks();
 		expect(saveDayTasksPromise).toBeInstanceOf(Promise);
-
-		expect(localStorage.getItem('day-tasks')).toBeNull();
-
-		const saveDayTasksResult = await saveDayTasksPromise;
-		expect(saveDayTasksResult).toBeUndefined();
+		await expect(saveDayTasksPromise).resolves.toBeUndefined();
 
 		expect(JSON.parse(localStorage.getItem('day-tasks')!)).toEqual([
 			['2023-11-13_1', firstDayTaskInfo],

--- a/app/assets/js/src/data/dayTasks/persistence/saveDayTasks.ts
+++ b/app/assets/js/src/data/dayTasks/persistence/saveDayTasks.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { dayTasksRegister } from '../dayTasksRegister';
 
 /**
@@ -6,9 +8,5 @@ import { dayTasksRegister } from '../dayTasksRegister';
 export async function saveDayTasks(): Promise<void> {
 	const dayTasksInfo = Array.from(dayTasksRegister.entries());
 
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
-
-	localStorage.setItem('day-tasks', JSON.stringify(dayTasksInfo));
+	await ls.set('day-tasks', dayTasksInfo);
 }

--- a/app/assets/js/src/data/days/persistence/loadDays.ts
+++ b/app/assets/js/src/data/days/persistence/loadDays.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { daysRegister } from '../daysRegister';
 import { updateOldDayInfo } from './updateOldDayInfo';
 
@@ -9,20 +11,18 @@ import { updateOldDayInfo } from './updateOldDayInfo';
  * or rejects when days info fails to load.
  */
 export async function loadDays(serialisedDaysInfo?: string): Promise<void> {
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
+	const persistedDaysInfo = await (() => {
+		if (typeof serialisedDaysInfo !== 'undefined') {
+			return JSON.parse(serialisedDaysInfo);
+		}
 
-	if (typeof serialisedDaysInfo === 'undefined') {
-		serialisedDaysInfo = localStorage.getItem('days') ?? undefined;
-	}
+		return ls.get('days');
+	})();
 
-	if (!serialisedDaysInfo) {
+	if (persistedDaysInfo === null) {
 		daysRegister.clear();
 		return;
 	}
-
-	const persistedDaysInfo = JSON.parse(serialisedDaysInfo);
 
 	if (!(
 		Array.isArray(persistedDaysInfo) &&

--- a/app/assets/js/src/data/days/persistence/saveDays.test.ts
+++ b/app/assets/js/src/data/days/persistence/saveDays.test.ts
@@ -26,18 +26,14 @@ describe('saveDays', () => {
 	});
 
 	test('returns a Promise that resolves when the content of the days register has been persisted', async () => {
+		expect(localStorage.getItem('days')).toBeNull();
+
 		setDayInfo('2023-11-09', ninthDayInfo);
 		setDayInfo('2023-11-10', tenthDayInfo);
 
-		expect(localStorage.getItem('days')).toBeNull();
-
 		const saveDaysPromise = saveDays();
 		expect(saveDaysPromise).toBeInstanceOf(Promise);
-
-		expect(localStorage.getItem('days')).toBeNull();
-
-		const saveDaysResult = await saveDaysPromise;
-		expect(saveDaysResult).toBeUndefined();
+		await expect(saveDaysPromise).resolves.toBeUndefined();
 
 		expect(localStorage.getItem('days')).toEqual(JSON.stringify([
 			['2023-11-09', { name: '2023-11-09', ...ninthDayInfo }],

--- a/app/assets/js/src/data/days/persistence/saveDays.ts
+++ b/app/assets/js/src/data/days/persistence/saveDays.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { daysRegister } from '../daysRegister';
 
 /**
@@ -6,9 +8,5 @@ import { daysRegister } from '../daysRegister';
 export async function saveDays(): Promise<void> {
 	const daysInfo = Array.from(daysRegister.entries());
 
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
-
-	localStorage.setItem('days', JSON.stringify(daysInfo));
+	await ls.set('days', daysInfo);
 }

--- a/app/assets/js/src/data/tasks/persistence/loadTasks.ts
+++ b/app/assets/js/src/data/tasks/persistence/loadTasks.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { tasksRegister } from '../tasksRegister';
 import { updateOldTaskInfo } from '../updateOldTaskInfo';
 
@@ -9,20 +11,18 @@ import { updateOldTaskInfo } from '../updateOldTaskInfo';
  * or rejects when tasks info fails to load.
  */
 export async function loadTasks(serialisedTasksInfo?: string): Promise<void> {
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
+	const persistedTasksInfo = await (() => {
+		if (typeof serialisedTasksInfo !== 'undefined') {
+			return JSON.parse(serialisedTasksInfo);
+		}
 
-	if (typeof serialisedTasksInfo === 'undefined') {
-		serialisedTasksInfo = localStorage.getItem('tasks') ?? undefined;
-	}
+		return ls.get('tasks');
+	})();
 
-	if (!serialisedTasksInfo) {
+	if (persistedTasksInfo === null) {
 		tasksRegister.clear();
 		return;
 	}
-
-	const persistedTasksInfo = JSON.parse(serialisedTasksInfo);
 
 	if (!(
 		Array.isArray(persistedTasksInfo) &&

--- a/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
+++ b/app/assets/js/src/data/tasks/persistence/saveTasks.test.ts
@@ -36,18 +36,14 @@ describe('saveDays', () => {
 	});
 
 	test('returns a Promise that resolves when the content of the tasks register has been persisted', async () => {
+		expect(localStorage.getItem('tasks')).toBeNull();
+
 		setTaskInfo(1, firstTaskInfo);
 		setTaskInfo(2, secondTaskInfo);
 
-		expect(localStorage.getItem('tasks')).toBeNull();
-
 		const saveDaysPromise = saveTasks();
 		expect(saveDaysPromise).toBeInstanceOf(Promise);
-
-		expect(localStorage.getItem('tasks')).toBeNull();
-
-		const saveDaysResult = await saveDaysPromise;
-		expect(saveDaysResult).toBeUndefined();
+		await expect(saveDaysPromise).resolves.toBeUndefined();
 
 		expect(localStorage.getItem('tasks')).toEqual(JSON.stringify([
 			[1, firstTaskInfo],

--- a/app/assets/js/src/data/tasks/persistence/saveTasks.ts
+++ b/app/assets/js/src/data/tasks/persistence/saveTasks.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { tasksRegister } from '../tasksRegister';
 
 /**
@@ -6,9 +8,5 @@ import { tasksRegister } from '../tasksRegister';
 export async function saveTasks(): Promise<void> {
 	const tasksInfo = Array.from(tasksRegister.entries());
 
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
-
-	localStorage.setItem('tasks', JSON.stringify(tasksInfo));
+	await ls.set('tasks', tasksInfo);
 }

--- a/app/assets/js/src/data/templates/persistence/loadTemplates.ts
+++ b/app/assets/js/src/data/templates/persistence/loadTemplates.ts
@@ -1,3 +1,4 @@
+import { ls } from 'persist';
 import { templatesRegister } from '../templatesRegister';
 import { updateOldTemplateInfo } from './updateOldTemplateInfo';
 
@@ -9,20 +10,18 @@ import { updateOldTemplateInfo } from './updateOldTemplateInfo';
  * or rejects when templates info fails to load.
  */
 export async function loadTemplates(serialisedTemplatesInfo?: string): Promise<void> {
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
+	const persistedTemplatesInfo = await (() => {
+		if (typeof serialisedTemplatesInfo !== 'undefined') {
+			return JSON.parse(serialisedTemplatesInfo);
+		}
 
-	if (typeof serialisedTemplatesInfo === 'undefined') {
-		serialisedTemplatesInfo = localStorage.getItem('templates') ?? undefined;
-	}
+		return ls.get('templates');
+	})();
 
-	if (!serialisedTemplatesInfo) {
+	if (persistedTemplatesInfo === null) {
 		templatesRegister.clear();
 		return;
 	}
-
-	const persistedTemplatesInfo = JSON.parse(serialisedTemplatesInfo);
 
 	if (!(
 		Array.isArray(persistedTemplatesInfo) &&

--- a/app/assets/js/src/data/templates/persistence/saveTemplates.test.ts
+++ b/app/assets/js/src/data/templates/persistence/saveTemplates.test.ts
@@ -31,18 +31,14 @@ describe('saveTemplates', () => {
 	});
 
 	test('returns a Promise that resolves when the content of the templates register has been persisted', async () => {
+		expect(localStorage.getItem('templates')).toBeNull();
+
 		setTemplateInfo(1, firstTemplateInfo);
 		setTemplateInfo(2, secondTemplateInfo);
 
-		expect(localStorage.getItem('templates')).toBeNull();
-
 		const saveTemplatesPromise = saveTemplates();
 		expect(saveTemplatesPromise).toBeInstanceOf(Promise);
-
-		expect(localStorage.getItem('templates')).toBeNull();
-
-		const saveTemplatesResult = await saveTemplatesPromise;
-		expect(saveTemplatesResult).toBeUndefined();
+		await expect(saveTemplatesPromise).resolves.toBeUndefined();
 
 		expect(localStorage.getItem('templates')).toEqual(JSON.stringify([
 			[1, { id: 1, ...firstTemplateInfo }],

--- a/app/assets/js/src/data/templates/persistence/saveTemplates.ts
+++ b/app/assets/js/src/data/templates/persistence/saveTemplates.ts
@@ -1,3 +1,5 @@
+import { ls } from 'persist';
+
 import { templatesRegister } from '../templatesRegister';
 
 /**
@@ -6,9 +8,5 @@ import { templatesRegister } from '../templatesRegister';
 export async function saveTemplates(): Promise<void> {
 	const templatesInfo = Array.from(templatesRegister.entries());
 
-	// Until we use an asynchronous API to store this data, emulate
-	// it by using the microtask queue.
-	await new Promise<void>((resolve) => queueMicrotask(resolve));
-
-	localStorage.setItem('templates', JSON.stringify(templatesInfo));
+	return ls.set('templates', templatesInfo);
 }

--- a/app/assets/js/src/persist/PersistApi.ts
+++ b/app/assets/js/src/persist/PersistApi.ts
@@ -1,0 +1,31 @@
+export interface PersistApi {
+	/**
+	 * Saves data to persistent storage.
+	 *
+	 * @param key - A string key to save data against for later retrieval
+	 * @param data - A JSON serialisable value to store.
+	 *
+	 * @returns A `Promise` that resolves when the storage is complete.
+	 */
+	set(key: string, data: unknown): Promise<void>;
+
+	/**
+	 * Retrives data from persistent storage.
+	 *
+	 * @param key - The string key where the persisted data has been saved.
+	 *
+	 * @returns A `Promise` that resolves with the value that was saved against.
+	 * the specified key, or `null` if no data was persisted.
+	 */
+	get(key: string): Promise<unknown>;
+
+	/**
+	 * Deletes data from persistent storage. If no data is stored against
+	 * the specified key, this function does nothing.
+	 *
+	 * @param key - The string key where data should be deleted.
+	 *
+	 * @returns A `Promise` that resolves when the value has been deleted.
+	 */
+	delete(key: string): Promise<void>;
+}

--- a/app/assets/js/src/persist/index.ts
+++ b/app/assets/js/src/persist/index.ts
@@ -1,0 +1,1 @@
+export { ls } from './ls';

--- a/app/assets/js/src/persist/ls.test.ts
+++ b/app/assets/js/src/persist/ls.test.ts
@@ -1,0 +1,105 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+
+import { ls } from 'persist';
+
+const { localStorage } = window;
+
+describe('localStorage', () => {
+	afterEach(() => {
+		window.localStorage = localStorage;
+		localStorage.clear();
+	});
+
+	describe('set', () => {
+		test('returns a Promise that resolves when data has been stored', async () => {
+			const result = ls.set('test', 1);
+			expect(result).toBeInstanceOf(Promise);
+
+			expect(await result).toBeUndefined();
+			expect(
+				JSON.parse(localStorage.getItem('test')!)
+			).toBe(1);
+		});
+
+		test('rejects if data could not be serialised', async () => {
+			await expect(
+				ls.set('test', 1n)
+			).rejects.toBeInstanceOf(Error);
+		});
+
+		test('rejects if localStorage is not available', async () => {
+			// @ts-expect-error Just deleting localStorage for a test
+			delete window.localStorage;
+
+			await expect(
+				ls.set('test', 1)
+			).rejects.toBeInstanceOf(Error);
+		});
+	});
+
+	describe('get', () => {
+		beforeEach(() => {
+			ls.set('test', { foo: 'bar' });
+		});
+
+		test('returns a Promise that resolves with persisted data', async () => {
+			const result = ls.get('test');
+			expect(result).toBeInstanceOf(Promise);
+
+			const data = await result;
+			expect(data).toEqual({ foo: 'bar' });
+		});
+
+		test('returns a Promise that resolves with null if there is no persisted data', async () => {
+			expect(
+				await ls.get('nothing')
+			).toBeNull();
+		});
+
+		test('rejects if localStorage is not available', async () => {
+			// @ts-expect-error Just deleting localStorage for a test
+			delete window.localStorage;
+
+			await expect(
+				ls.get('test')
+			).rejects.toBeInstanceOf(Error);
+		});
+	});
+
+	describe('delete', () => {
+		beforeEach(() => {
+			ls.set('test', { foo: 'bar' });
+		});
+
+		test('returns a Promise that resolves when persisted data has been deleted', async () => {
+			const result = ls.delete('test');
+			expect(result).toBeInstanceOf(Promise);
+
+			expect(await result).toBeUndefined();
+			expect(
+				await ls.get('test')
+			).toBeNull();
+		});
+
+		test('does nothing if no data was persisted at the given key', async () => {
+			await expect(
+				ls.delete('nothing')
+			).resolves.toBeUndefined();
+		});
+
+		test('rejects if localStorage is not available', async () => {
+			// @ts-expect-error Just deleting localStorage for a test
+			delete window.localStorage;
+
+			await expect(
+				ls.delete('test')
+			).rejects.toBeInstanceOf(Error);
+		});
+	});
+});

--- a/app/assets/js/src/persist/ls.ts
+++ b/app/assets/js/src/persist/ls.ts
@@ -1,0 +1,46 @@
+import type { PersistApi } from 'persist/PersistApi';
+
+/**
+ * A {@linkcode PersistApi} interface for working with the
+ * localStorage API.
+ */
+export const ls: PersistApi = {
+	set(key, data) {
+		return new Promise((resolve, reject) => {
+			try {
+				const jsonData = JSON.stringify(data);
+				localStorage.setItem(key, jsonData);
+				resolve();
+			} catch (e) {
+				reject(e);
+			}
+		});
+	},
+
+	get(key) {
+		return new Promise((resolve, reject) => {
+			try {
+				const jsonData = localStorage.getItem(key);
+				if (jsonData === null) {
+					resolve(null);
+					return;
+				}
+				const data = JSON.parse(jsonData);
+				resolve(data);
+			} catch (e) {
+				reject(e);
+			}
+		});
+	},
+
+	delete(key) {
+		return new Promise((resolve, reject) => {
+			try {
+				localStorage.removeItem(key);
+				resolve();
+			} catch (e) {
+				reject(e);
+			}
+		});
+	},
+};


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Orange Twist currently uses the LocalStorage API for persisting data. This works well enough for small amounts of data stored locally, but it has some shortcomings:

- There is a cap of ~5MB of storage per origin
- No way to sync data between devices

If Orange Twist is ever going to support features like embedding images or syncing data between devices, it's going to need to be able to use a different persistence medium that doesn't have the same shortcomings as the LocalStorage API.

<!-- Describe your solution -->

This PR implements a `PersistApi` interface that can be used to interact with different persistence media, such as IndexedDB or a REST API. For now, it only implements an adapter for the LocalStorage API.

<!-- Complete each item in this pre-merge checklist -->

I'm forgoing the version checklist for this PR because it makes no functional changes.

- [ ] ~~The version number has been updated in `package.json`~~
- [ ] ~~The version number has been updated in `Footer.tsx`~~
- [ ] ~~A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)~~
