### PR TITLE
Refactored InlineNote to fix discard changes on escape behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0] - 2024-04-20
+## [1.5.0] - 2024-04-26
 
 ### Added
 
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * "Request a feature" link now opens in a new tab
 * Nested markdown lists with checkboxes have better spacing
 * Tool drawers are larger and easier to open on intermediate devices
+* Pressing "Escape" to cancel changes to an inline note now works correctly
 
 ## [1.4.1] - 2024-04-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.4.1",
+			"version": "1.5.0",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.9.0",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When pressing "Escape" to cancel changes to an inline note, it wasn't properly exiting edit mode.

<!-- Describe your solution -->
This PR refactors the `<InlineNote>` component to better manage its `dirtyFlag` to recognise when the note has been reset, and removes some no longer necessary complex behaviour around blurring the input.

<!-- List any issues that are resolved by this PR -->
Resolves #142 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
