### PR TITLE
Refactored Markdown init and language handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Nested markdown lists with checkboxes have better spacing
 * Tool drawers are larger and easier to open on intermediate devices
 * Pressing "Escape" to cancel changes to an inline note now works correctly
+* Syntax highlighting now works correctly for HTML and XML code blocks
 
 ## [1.4.1] - 2024-04-13
 

--- a/app/assets/js/src/components/shared/Markdown/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown/Markdown.tsx
@@ -27,21 +27,32 @@ interface MarkdownProps extends h.JSX.HTMLAttributes<HTMLDivElement> {
 	inline?: boolean;
 }
 
-marked.use({
-	renderer,
-	extensions: [
-		taskLink,
-		template,
-	],
-});
+let isMarkedInitialised = false;
+/**
+ * Initialise the "marked" package once before use.
+ */
+function initMarked() {
+	if (isMarkedInitialised) {
+		return;
+	}
+	isMarkedInitialised = true;
 
-marked.use(markedHighlight({
-	langPrefix: 'hljs language-',
-	highlight(code, lang, info) {
-		const language = hljs.getLanguage(lang)?.name ?? 'plaintext';
-		return hljs.highlight(code, { language }).value;
-	},
-}));
+	marked.use({
+		renderer,
+		extensions: [
+			taskLink,
+			template,
+		],
+	});
+
+	marked.use(markedHighlight({
+		langPrefix: 'hljs language-',
+		highlight(code, lang, info) {
+			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+			return hljs.highlight(code, { language }).value;
+		},
+	}));
+}
 
 export function Markdown(props: MarkdownProps): JSX.Element {
 	const {
@@ -76,6 +87,7 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 		})();
 
 		(async () => {
+			initMarked();
 			let renderedContent = marked.parse(contentToRender, {
 				breaks: true,
 			});


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When trying to apply "html" syntax highlighting in Markdown, a JavaScript error breaks the rendering.

<!-- Describe your solution -->
This PR changes the way language information is retrieved so it works correctly for HTML/XML. It also refactors the `<Markdown>` component slightly so importing it doesn't have side effects.

<!-- List any issues that are resolved by this PR -->
Resolves #111

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json` _The version number is already correct_
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
