### PR TITLE
Fix large image embed focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0] - 2024-04-26
+## [1.5.1] - 2024-05-21
+
+### Fixed
+
+* Notes stay in editing mode while confirming whether or not to embed a large image
+
+## [1.5.0] - 2024-05-21
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.5.0",
+			"version": "1.5.1",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
While confirming whether or not to attach a large image, focus leaves the note it's being embedded in and this causes it to leave editing mode.

<!-- Describe your solution -->
So long as the prompt to attach a large image is visible, a note's editing mode becomes immutable. Once the prompt is closed, focus is moved back to the textarea.

<!-- List any issues that are resolved by this PR -->
Resolves #158

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
