### PR TITLE
Fix task link broken initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2024-05-25
+
+### Fixed
+
+* Task links will no longer get stuck in a "No task with ID X" state on initial load.
+
 ## [1.5.1] - 2024-05-21
 
 ### Fixed

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
@@ -11,9 +11,9 @@ import {
 
 import {
 	InlineNote,
-	Note,
 } from 'components/shared';
 import { TaskStatusComponent } from '../TaskStatusComponent';
+import { DayTaskNote } from './DayTaskNote';
 
 interface DayTaskDetailProps {
 	dayTaskInfo: DayTaskInfo;
@@ -28,7 +28,6 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 	const {
 		dayName,
 		taskId,
-		note,
 	} = dayTaskInfo;
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
@@ -56,13 +55,7 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 		</summary>
 
 		<div class="day__body">
-			<Note
-				note={note}
-				onNoteChange={useCallback((note: string) => {
-					setDayTaskInfo({ dayName, taskId }, { note });
-				}, [dayName, taskId])}
-				saveChanges={saveChanges}
-			/>
+			<DayTaskNote dayTask={dayTaskInfo} />
 		</div>
 	</details>;
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -1,42 +1,34 @@
 import { h, type JSX } from 'preact';
 import { useCallback, useContext } from 'preact/hooks';
 
-import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
+import { Command } from 'types/Command';
 
-import {
-	setDayInfo,
-	type DayInfo,
-} from 'data';
+import { setDayTaskInfo, type DayTaskInfo } from 'data';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { Note } from 'components/shared';
 
-interface DayNoteProps {
-	day: Readonly<DayInfo>;
+interface DayTaskNoteProps {
+	dayTask: Readonly<DayTaskInfo>;
 }
 
-/**
- * Renders a note for a specified day, including the ability to
- * edit that note.
- */
-export function DayNote(props: DayNoteProps): JSX.Element {
-	const { day } = props;
-	const { name } = day;
+export function DayTaskNote(props: DayTaskNoteProps): JSX.Element {
+	const { dayTask } = props;
+	const { dayName, taskId } = dayTask;
 
 	// Reload when all data is loaded, to make sure it's all displayed correctly
 	useContext(OrangeTwistContext);
 
-	const onNoteChange = useCallback(
-		(note: string) => setDayInfo(name, { note }),
-		[name]
-	);
+	const setDayTaskNote = useCallback((note: string) => {
+		setDayTaskInfo({ dayName, taskId }, { note });
+	}, [dayName, taskId]);
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
 	return <Note
-		note={day.note}
-		onNoteChange={onNoteChange}
+		note={dayTask.note}
+		onNoteChange={setDayTaskNote}
 		saveChanges={saveChanges}
 	/>;
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
@@ -13,7 +13,6 @@ import { Command } from 'types/Command';
 import {
 	getDayTaskInfo,
 	setDayTaskInfo,
-	setTaskInfo,
 	useAllDayTaskInfo,
 	useTaskInfo,
 } from 'data';
@@ -24,12 +23,12 @@ import {
 	Button,
 	Loader,
 	Markdown,
-	Note,
 	Notice,
 } from 'components/shared';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { DayTaskDetail } from './DayTaskDetail';
+import { TaskNote } from './TaskNote';
 
 interface TaskDetailProps {
 	taskId: number;
@@ -53,15 +52,6 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 	const dayTasksInfo = useMemo(() => unsortedDayTasksInfo.toSorted(
 		({ dayName: dayNameA }, { dayName: dayNameB }) => dayNameA.localeCompare(dayNameB)
 	), [unsortedDayTasksInfo]);
-
-	const setTaskNote = useCallback(
-		(note: string) => {
-			setTaskInfo(taskId, { note });
-		},
-		[taskId]
-	);
-
-	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
 	const addNewDayTask = useCallback(async () => {
 		const dayName = await ui.prompt('What day?', { type: 'date' });
@@ -117,12 +107,7 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 			content={`## ${taskInfo.name}`}
 			inline
 		/>
-		<Note
-			class="task-detail__note"
-			note={taskInfo.note}
-			onNoteChange={setTaskNote}
-			saveChanges={saveChanges}
-		/>
+		<TaskNote task={taskInfo} />
 		{dayTasksInfo.map((dayTaskInfo, i, arr) => (
 			<DayTaskDetail
 				key={dayTaskInfo.dayName}

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -1,42 +1,37 @@
 import { h, type JSX } from 'preact';
 import { useCallback, useContext } from 'preact/hooks';
 
-import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
+import { Command } from 'types/Command';
 
-import {
-	setDayInfo,
-	type DayInfo,
-} from 'data';
+import { setTaskInfo, type TaskInfo } from 'data';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { Note } from 'components/shared';
 
-interface DayNoteProps {
-	day: Readonly<DayInfo>;
+interface TaskNoteProps {
+	task: Readonly<TaskInfo>;
 }
 
-/**
- * Renders a note for a specified day, including the ability to
- * edit that note.
- */
-export function DayNote(props: DayNoteProps): JSX.Element {
-	const { day } = props;
-	const { name } = day;
+export function TaskNote(props: TaskNoteProps): JSX.Element {
+	const { task } = props;
 
 	// Reload when all data is loaded, to make sure it's all displayed correctly
 	useContext(OrangeTwistContext);
 
-	const onNoteChange = useCallback(
-		(note: string) => setDayInfo(name, { note }),
-		[name]
+	const setTaskNote = useCallback(
+		(note: string) => {
+			setTaskInfo(task.id, { note });
+		},
+		[task.id]
 	);
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
 	return <Note
-		note={day.note}
-		onNoteChange={onNoteChange}
+		class="task-detail__note"
+		note={task.note}
+		onNoteChange={setTaskNote}
 		saveChanges={saveChanges}
 	/>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.5.1",
+			"version": "1.5.2",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
I've noticed day notes sometimes render incorrectly when initially loading. In particular, task links sometimes display "No task with ID X" when there is actually a task with that ID, because the note was rendered before the task info had finished loading.

<!-- Describe your solution -->
This PR refactors notes for tasks and day tasks to match day notes, and hooks each of them up to re-render when data is finished loading.

Notes may still display incorrectly during the initial load, but once data has finished loading they will be re-rendered and this should fill in any missing information. I know this is still a bit rough, but I preferred it to displaying a loader and hiding parts of the note that can be displayed.

In the future, this loading state could be used to change the error state of task links etc. so the message is about fetching the relevant data instead.

<!-- List any issues that are resolved by this PR -->
Resolves #149

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
