### PR TITLE
Allow summaries to wrap on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* Day summaries can now wrap on mobile
 * Empty tool drawers no longer show
 * Task links will no longer get stuck in a "No task with ID X" state on initial load.
 

--- a/app/assets/scss/components/_day.scss
+++ b/app/assets/scss/components/_day.scss
@@ -1,3 +1,4 @@
+@use "../theme/layout";
 @use "../theme/palette";
 @use "../theme/spacing";
 @use "../theme/typography";
@@ -23,6 +24,10 @@
 	display: flex;
 	gap: spacing.$sm;
 	align-items: center;
+
+	@include layout.bp-small {
+		flex-wrap: wrap;
+	}
 }
 
 .day__body {


### PR DESCRIPTION
<!-- Describe the problem being solved -->
On mobile, day summaries are squished into a tiny amount of space and are basically unusable.

<!-- Describe your solution -->
This PR allows day summaries to wrap to their own line on mobile.

<!-- List any issues that are resolved by this PR -->
Resolves #164 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
