### PR TITLE
Task link bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.3] - 2024-07-20
+## [1.5.3] - 2024-07-21
 
 ### Fixed
 
 * Tasks can now be reordered on touch devices
+* Task links will no longer get stuck in a "No task with ID X" state on initial load while there is image data.
 
 ### Changed
 

--- a/app/assets/js/src/components/days/DayNote.tsx
+++ b/app/assets/js/src/components/days/DayNote.tsx
@@ -1,5 +1,5 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useContext } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -9,7 +9,6 @@ import {
 	type DayInfo,
 } from 'data';
 
-import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { Note } from 'components/shared';
 
 interface DayNoteProps {
@@ -23,9 +22,6 @@ interface DayNoteProps {
 export function DayNote(props: DayNoteProps): JSX.Element {
 	const { day } = props;
 	const { name } = day;
-
-	// Reload when all data is loaded, to make sure it's all displayed correctly
-	useContext(OrangeTwistContext);
 
 	const onNoteChange = useCallback(
 		(note: string) => setDayInfo(name, { note }),

--- a/app/assets/js/src/components/days/DayNote.tsx
+++ b/app/assets/js/src/components/days/DayNote.tsx
@@ -1,5 +1,10 @@
 import { h, type JSX } from 'preact';
-import { useCallback } from 'preact/hooks';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+} from 'preact/hooks';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -9,6 +14,9 @@ import {
 	type DayInfo,
 } from 'data';
 
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
+
+import type { MarkdownApi } from 'components/shared/Markdown';
 import { Note } from 'components/shared';
 
 interface DayNoteProps {
@@ -23,6 +31,8 @@ export function DayNote(props: DayNoteProps): JSX.Element {
 	const { day } = props;
 	const { name } = day;
 
+	const { isLoading } = useContext(OrangeTwistContext);
+
 	const onNoteChange = useCallback(
 		(note: string) => setDayInfo(name, { note }),
 		[name]
@@ -30,9 +40,18 @@ export function DayNote(props: DayNoteProps): JSX.Element {
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
+	const markdownApiRef = useRef<MarkdownApi | null>(null);
+	// When data is finished loading re-render Markdown
+	useEffect(() => {
+		if (!isLoading) {
+			markdownApiRef.current?.rerender();
+		}
+	}, [isLoading]);
+
 	return <Note
 		note={day.note}
 		onNoteChange={onNoteChange}
 		saveChanges={saveChanges}
+		markdownApiRef={markdownApiRef}
 	/>;
 }

--- a/app/assets/js/src/components/shared/Markdown/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown/Markdown.tsx
@@ -121,6 +121,7 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 		setRenderSwitch(!renderSwitch);
 	}, [renderSwitch]);
 
+	// Expose API
 	useEffect(() => {
 		if (apiRef) {
 			apiRef.current = { rerender };

--- a/app/assets/js/src/components/shared/Markdown/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown/Markdown.tsx
@@ -1,5 +1,9 @@
 import { h, type JSX } from 'preact';
-import { useLayoutEffect, useRef } from 'preact/hooks';
+import {
+	useContext,
+	useLayoutEffect,
+	useRef,
+} from 'preact/hooks';
 
 import { classNames } from 'utils';
 
@@ -15,6 +19,7 @@ import { renderer } from './renderer';
 
 import { useAllTemplateInfo } from 'data';
 import { consumeAllImageUrlPlaceholders } from 'images';
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 interface MarkdownProps extends h.JSX.HTMLAttributes<HTMLDivElement> {
 	/**
@@ -68,6 +73,9 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 
 	// Re-render whenever a template changes
 	const templates = useAllTemplateInfo();
+
+	// Re-render when data is loaded to ensure task notes etc. display correctly
+	const { isLoading } = useContext(OrangeTwistContext);
 
 	// Render content as markup
 	// Using `useLayoutEffect` prevents jittering caused by setting HTML after Preact renders
@@ -128,7 +136,12 @@ export function Markdown(props: MarkdownProps): JSX.Element {
 				}
 			}
 		})();
-	}, [content, inline, templates]);
+	}, [
+		content,
+		inline,
+		templates,
+		isLoading,
+	]);
 
 	return <div
 		ref={wrapperRef}

--- a/app/assets/js/src/components/shared/Markdown/index.ts
+++ b/app/assets/js/src/components/shared/Markdown/index.ts
@@ -1,1 +1,1 @@
-export { Markdown } from './Markdown';
+export { Markdown, type MarkdownApi } from './Markdown';

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -1,4 +1,8 @@
-import { h, type JSX } from 'preact';
+import {
+	h,
+	type JSX,
+	type RefObject,
+} from 'preact';
 
 import {
 	useCallback,
@@ -28,13 +32,19 @@ import {
 
 import * as ui from 'ui';
 
-import { Markdown } from './Markdown';
+import { Markdown, type MarkdownApi } from './Markdown';
 import { IconButton } from './IconButton';
 
 interface NoteProps {
 	note: string | null;
 	onNoteChange: (note: string) => void;
 	saveChanges: () => void;
+
+	/**
+	 * If a ref object is provided, it will be set to expose
+	 * a {@linkcode MarkdownApi} object.
+	 */
+	markdownApiRef?: RefObject<MarkdownApi>;
 
 	class?: string;
 }
@@ -482,6 +492,7 @@ export function Note(props: NoteProps): JSX.Element {
 					<Markdown
 						content={note}
 						onClick={enterEditingModeOnNoteClick}
+						apiRef={props.markdownApiRef}
 					/>
 				}
 				<IconButton

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -1,12 +1,11 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useContext } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
 import { setDayTaskInfo, type DayTaskInfo } from 'data';
 
-import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { Note } from 'components/shared';
 
 interface DayTaskNoteProps {
@@ -16,9 +15,6 @@ interface DayTaskNoteProps {
 export function DayTaskNote(props: DayTaskNoteProps): JSX.Element {
 	const { dayTask } = props;
 	const { dayName, taskId } = dayTask;
-
-	// Reload when all data is loaded, to make sure it's all displayed correctly
-	useContext(OrangeTwistContext);
 
 	const setDayTaskNote = useCallback((note: string) => {
 		setDayTaskInfo({ dayName, taskId }, { note });

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -1,12 +1,20 @@
 import { h, type JSX } from 'preact';
-import { useCallback } from 'preact/hooks';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+} from 'preact/hooks';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
 import { setDayTaskInfo, type DayTaskInfo } from 'data';
 
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
+
 import { Note } from 'components/shared';
+import type { MarkdownApi } from 'components/shared/Markdown';
 
 interface DayTaskNoteProps {
 	dayTask: Readonly<DayTaskInfo>;
@@ -16,15 +24,26 @@ export function DayTaskNote(props: DayTaskNoteProps): JSX.Element {
 	const { dayTask } = props;
 	const { dayName, taskId } = dayTask;
 
+	const { isLoading } = useContext(OrangeTwistContext);
+
 	const setDayTaskNote = useCallback((note: string) => {
 		setDayTaskInfo({ dayName, taskId }, { note });
 	}, [dayName, taskId]);
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
+	const markdownApiRef = useRef<MarkdownApi | null>(null);
+	// When data is finished loading re-render Markdown
+	useEffect(() => {
+		if (!isLoading) {
+			markdownApiRef.current?.rerender();
+		}
+	}, [isLoading]);
+
 	return <Note
 		note={dayTask.note}
 		onNoteChange={setDayTaskNote}
 		saveChanges={saveChanges}
+		markdownApiRef={markdownApiRef}
 	/>;
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -13,8 +13,8 @@ import { setDayTaskInfo, type DayTaskInfo } from 'data';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
-import { Note } from 'components/shared';
 import type { MarkdownApi } from 'components/shared/Markdown';
+import { Note } from 'components/shared';
 
 interface DayTaskNoteProps {
 	dayTask: Readonly<DayTaskInfo>;

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -1,12 +1,11 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useContext } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
 import { setTaskInfo, type TaskInfo } from 'data';
 
-import { OrangeTwistContext } from 'components/OrangeTwistContext';
 import { Note } from 'components/shared';
 
 interface TaskNoteProps {
@@ -15,9 +14,6 @@ interface TaskNoteProps {
 
 export function TaskNote(props: TaskNoteProps): JSX.Element {
 	const { task } = props;
-
-	// Reload when all data is loaded, to make sure it's all displayed correctly
-	useContext(OrangeTwistContext);
 
 	const setTaskNote = useCallback(
 		(note: string) => {

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -1,11 +1,19 @@
 import { h, type JSX } from 'preact';
-import { useCallback } from 'preact/hooks';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+} from 'preact/hooks';
 
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
 import { setTaskInfo, type TaskInfo } from 'data';
 
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
+
+import type { MarkdownApi } from 'components/shared/Markdown';
 import { Note } from 'components/shared';
 
 interface TaskNoteProps {
@@ -14,6 +22,8 @@ interface TaskNoteProps {
 
 export function TaskNote(props: TaskNoteProps): JSX.Element {
 	const { task } = props;
+
+	const { isLoading } = useContext(OrangeTwistContext);
 
 	const setTaskNote = useCallback(
 		(note: string) => {
@@ -24,10 +34,19 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
+	const markdownApiRef = useRef<MarkdownApi | null>(null);
+	// When data is finished loading re-render Markdown
+	useEffect(() => {
+		if (!isLoading) {
+			markdownApiRef.current?.rerender();
+		}
+	}, [isLoading]);
+
 	return <Note
 		class="task-detail__note"
 		note={task.note}
 		onNoteChange={setTaskNote}
 		saveChanges={saveChanges}
+		markdownApiRef={markdownApiRef}
 	/>;
 }


### PR DESCRIPTION
<!-- Describe the problem being solved -->

In #161, I made various note components re-render when data such as tasks was finished loading. Initially, this appeared to fix the issue where task links can get stuck in a "No task with ID X" state. However, it still happens when there is image data.

It turned out that forcing notes to re-render without changing their content was not causing `Markdown`components to re-render their content into markdown, so the newly loaded data was not being incorporated.

This PR exposes a new `MarkdownApi` object via a forwarded ref in an `apiRef` property in `Markdown`, which is forwarded again as `markdownApiRef` in the `Note` component. By using this API's `rerender` method in the individual note components, they can now force the content to be re-rendered to markdown after the data has finished loading.

I've been able to replicate the issue locally, and this seems to have properly solved it this time.

<!-- Describe your solution -->

<!-- List any issues that are resolved by this PR -->
Resolves #149

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
