### PR TITLE
Speed up initial page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2024-08-02
+
+### Changed
+
+* Sped up initial rendering
+
 ## [1.5.4] - 2024-08-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.5] - 2024-08-02
+## [1.5.5] - 2024-08-03
 
 ### Changed
 

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -6,6 +6,7 @@ import {
 import {
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from 'preact/hooks';
@@ -146,7 +147,7 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 
 	// Scroll to first open day when initial loading is complete
 	const hasDoneInitialScroll = useRef(false);
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (hasDoneInitialScroll.current) {
 			return;
 		}

--- a/app/assets/js/src/components/days/Day.tsx
+++ b/app/assets/js/src/components/days/Day.tsx
@@ -12,24 +12,22 @@ import {
 
 import * as ui from 'ui';
 
-import { Button } from '../shared';
+import { Accordion, Button } from '../shared';
 import { DayNote } from './DayNote';
 import { TaskList } from '../tasks/TaskList';
 
-interface DayProps extends h.JSX.HTMLAttributes<HTMLDetailsElement> {
+interface DayProps {
 	day: Readonly<DayInfo>;
+	open?: boolean;
 }
 
 /**
  * Renders a day, including its notes and tasks, in a disclosure.
- *
- * Props that can apply to a `<details>` element will be passed
- * through to that element.
  */
 export const Day = (props: DayProps): JSX.Element => {
 	const {
 		day,
-		...passthroughProps
+		open,
 	} = props;
 	const {
 		name,
@@ -55,14 +53,13 @@ export const Day = (props: DayProps): JSX.Element => {
 		fireCommand(Command.DATA_SAVE);
 	}, [name]);
 
-	return <details
-		class="day js-day"
-		{...passthroughProps}
-	>
-		<summary class="day__summary">
-			<h3 class="day__heading">{name}</h3>
-		</summary>
+	return <Accordion
+		className="day js-day"
+		initiallyOpen={open}
 
+		summaryClass="day__summary"
+		summary={<h3 class="day__heading">{name}</h3>}
+	>
 		<div class="day__body">
 			<Button
 				onClick={removeDay}
@@ -83,5 +80,5 @@ export const Day = (props: DayProps): JSX.Element => {
 				)}
 			>Add new task</Button>
 		</div>
-	</details>;
+	</Accordion>;
 };

--- a/app/assets/js/src/components/days/Day.tsx
+++ b/app/assets/js/src/components/days/Day.tsx
@@ -54,7 +54,7 @@ export const Day = (props: DayProps): JSX.Element => {
 	}, [name]);
 
 	return <Accordion
-		className="day js-day"
+		class="day js-day"
 		open={open}
 
 		summaryClass="day__summary"

--- a/app/assets/js/src/components/days/Day.tsx
+++ b/app/assets/js/src/components/days/Day.tsx
@@ -55,7 +55,7 @@ export const Day = (props: DayProps): JSX.Element => {
 
 	return <Accordion
 		className="day js-day"
-		initiallyOpen={open}
+		open={open}
 
 		summaryClass="day__summary"
 		summary={<h3 class="day__heading">{name}</h3>}

--- a/app/assets/js/src/components/shared/Accordion.test.tsx
+++ b/app/assets/js/src/components/shared/Accordion.test.tsx
@@ -4,11 +4,16 @@ import {
 	afterEach,
 	describe,
 	expect,
+	jest,
 	test,
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 
 import { Accordion } from './Accordion';
@@ -18,7 +23,21 @@ describe('Accordion', () => {
 		cleanup();
 	});
 
-	test('Renders its children only when open', async () => {
+	test('Renders its children immediately if initially open', () => {
+		const { getByText } = render(
+			<Accordion
+				summary="Title"
+				open
+			>
+				<span>Child</span>
+			</Accordion>
+		);
+
+		const child = getByText('Child');
+		expect(child).toBeInTheDocument();
+	});
+
+	test('Renders its children immediately when opened', async () => {
 		const user = userEvent.setup();
 
 		const { getByText, queryByText } = render(
@@ -36,6 +55,27 @@ describe('Accordion', () => {
 		expect(child).not.toBeInTheDocument();
 
 		await user.click(summary);
+
+		child = queryByText('Child');
+		expect(child).toBeInTheDocument();
+	});
+
+	test('Renders its children within 1.5 seconds', () => {
+		jest.useFakeTimers();
+		const { queryByText } = render(
+			<Accordion
+				summary="Title"
+			>
+				<span>Child</span>
+			</Accordion>
+		);
+
+		let child = queryByText('Child');
+		expect(child).not.toBeInTheDocument();
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		child = queryByText('Child');
 		expect(child).toBeInTheDocument();

--- a/app/assets/js/src/components/shared/Accordion.test.tsx
+++ b/app/assets/js/src/components/shared/Accordion.test.tsx
@@ -1,0 +1,43 @@
+import { h } from 'preact';
+
+import {
+	afterEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+
+import { Accordion } from './Accordion';
+
+describe('Accordion', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('Renders its children only when open', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, queryByText } = render(
+			<Accordion
+				summary="Title"
+			>
+				<span>Child</span>
+			</Accordion>
+		);
+
+		const summary = getByText('Title');
+		expect(summary).toBeInTheDocument();
+
+		let child = queryByText('Child');
+		expect(child).not.toBeInTheDocument();
+
+		await user.click(summary);
+
+		child = queryByText('Child');
+		expect(child).toBeInTheDocument();
+	});
+});

--- a/app/assets/js/src/components/shared/Accordion.tsx
+++ b/app/assets/js/src/components/shared/Accordion.tsx
@@ -10,7 +10,7 @@ import {
 } from 'preact/hooks';
 
 interface AccordionProps {
-	className?: string;
+	class?: string;
 	open?: boolean;
 
 	summary: string | JSX.Element;
@@ -21,7 +21,7 @@ interface AccordionProps {
 
 export function Accordion(props: AccordionProps): JSX.Element {
 	const {
-		className,
+		class: className,
 
 		summary,
 		summaryClass,

--- a/app/assets/js/src/components/shared/Accordion.tsx
+++ b/app/assets/js/src/components/shared/Accordion.tsx
@@ -1,0 +1,47 @@
+import {
+	h,
+	type ComponentChildren,
+	type JSX,
+} from 'preact';
+import {
+	useCallback,
+	useState,
+} from 'preact/hooks';
+
+interface AccordionProps {
+	className?: string;
+	initiallyOpen?: boolean;
+
+	summary: string | JSX.Element;
+	summaryClass?: string;
+
+	children: ComponentChildren;
+}
+
+export function Accordion(props: AccordionProps): JSX.Element {
+	const {
+		className,
+		initiallyOpen,
+
+		summary,
+		summaryClass,
+
+		children,
+	} = props;
+
+	const [isOpen, setIsOpen] = useState(initiallyOpen);
+
+	const handleToggle: JSX.GenericEventHandler<HTMLDetailsElement> = useCallback((e) => {
+		const detailsEl = e.currentTarget;
+		setIsOpen(detailsEl.open);
+	}, []);
+
+	return <details
+		class={className}
+		open={isOpen}
+		onToggle={handleToggle}
+	>
+		<summary class={summaryClass}>{summary}</summary>
+		{isOpen && children}
+	</details>;
+}

--- a/app/assets/js/src/components/shared/index.ts
+++ b/app/assets/js/src/components/shared/index.ts
@@ -1,3 +1,4 @@
+export { Accordion } from './Accordion';
 export { Button } from './Button';
 export { ButtonVariant } from './types/ButtonVariant';
 export { DragList } from './DragList';

--- a/app/assets/js/src/components/tasks/CompletedTaskList.test.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.test.tsx
@@ -5,11 +5,16 @@ import {
 	beforeEach,
 	describe,
 	expect,
+	jest,
 	test,
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 
 import { TaskStatus } from 'types/TaskStatus';
 import {
@@ -96,7 +101,12 @@ describe('CompletedTaskList', () => {
 	});
 
 	test('renders all completed tasks', () => {
+		jest.useFakeTimers();
 		const { queryByText } = render(<CompletedTaskList />);
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		expect(queryByText('Task two')).toBeInTheDocument();
 		expect(queryByText('Task three')).toBeInTheDocument();
@@ -107,7 +117,12 @@ describe('CompletedTaskList', () => {
 	});
 
 	test('renders completed tasks in reverse order of completion', () => {
+		jest.useFakeTimers();
 		const { queryAllByText } = render(<CompletedTaskList />);
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		const tasks = queryAllByText(/^Task /);
 		expect(tasks.map(({ textContent }) => textContent)).toEqual([

--- a/app/assets/js/src/components/tasks/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.tsx
@@ -15,7 +15,7 @@ import { TaskList } from './TaskList';
  */
 export function CompletedTaskList(): JSX.Element | null {
 	return <Accordion
-		className="orange-twist__section"
+		class="orange-twist__section"
 		summary={
 			<h2 class="orange-twist__title">Completed tasks</h2>
 		}

--- a/app/assets/js/src/components/tasks/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.tsx
@@ -7,17 +7,19 @@ import {
 	type TaskInfo,
 } from 'data';
 
+import { Accordion } from 'components/shared';
 import { TaskList } from './TaskList';
 
 /**
  * Renders a list of all completed tasks inside a disclosure.
  */
 export function CompletedTaskList(): JSX.Element | null {
-	return <details class="orange-twist__section">
-		<summary>
+	return <Accordion
+		className="orange-twist__section"
+		summary={
 			<h2 class="orange-twist__title">Completed tasks</h2>
-		</summary>
-
+		}
+	>
 		<TaskList
 			matcher={useCallback(
 				({ status }: TaskInfo) => CompletedTaskStatuses.has(status),
@@ -45,5 +47,5 @@ export function CompletedTaskList(): JSX.Element | null {
 			)}
 			className="orange-twist__task-list"
 		/>
-	</details>;
+	</Accordion>;
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.test.tsx
@@ -11,7 +11,11 @@ import {
 } from '@jest/globals';
 import '@testing-library/jest-dom/jest-globals';
 
-import { cleanup, render } from '@testing-library/preact';
+import {
+	act,
+	cleanup,
+	render,
+} from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 
 import { Command } from 'types/Command';
@@ -52,9 +56,14 @@ describe('DayTaskDetail', () => {
 	test('renders the day task\'s note', () => {
 		const dayTaskInfo = getDayTaskInfo({ dayName: '2023-12-22', taskId: 1 })!;
 
+		jest.useFakeTimers();
 		const { getByText } = render(<DayTaskDetail
 			dayTaskInfo={dayTaskInfo}
 		/>);
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		const status = getByText('Task note');
 		expect(status).toBeInTheDocument();
@@ -92,9 +101,14 @@ describe('DayTaskDetail', () => {
 		const user = userEvent.setup();
 		const dayTaskInfo = getDayTaskInfo({ dayName: '2023-12-22', taskId: 1 })!;
 
+		jest.useFakeTimers();
 		const { getByRole } = render(<DayTaskDetail
 			dayTaskInfo={dayTaskInfo}
 		/>);
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		const noteEditButton = getByRole('button', { name: 'Edit note' });
 		await user.click(noteEditButton);
@@ -122,9 +136,14 @@ describe('DayTaskDetail', () => {
 
 		const dayTaskInfo = getDayTaskInfo({ dayName: '2023-12-22', taskId: 1 })!;
 
+		jest.useFakeTimers();
 		const { getByRole } = render(<DayTaskDetail
 			dayTaskInfo={dayTaskInfo}
 		/>);
+
+		// Wait for idle rendering to complete
+		act(() => jest.advanceTimersByTime(1500));
+		jest.useRealTimers();
 
 		const noteEditButton = getByRole('button', { name: 'Edit note' });
 		expect(noteEditButton).toBeInTheDocument();

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
@@ -35,7 +35,7 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 
 	return <Accordion
 		key={dayName}
-		className="day js-day"
+		class="day js-day"
 		open={open}
 
 		summaryClass="day__summary"

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
@@ -36,7 +36,7 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 	return <Accordion
 		key={dayName}
 		className="day js-day"
-		initiallyOpen={open}
+		open={open}
 
 		summaryClass="day__summary"
 		summary={<>

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskDetail.tsx
@@ -10,6 +10,7 @@ import {
 } from 'data';
 
 import {
+	Accordion,
 	InlineNote,
 } from 'components/shared';
 import { TaskStatusComponent } from '../TaskStatusComponent';
@@ -32,12 +33,13 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 
 	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
-	return <details
+	return <Accordion
 		key={dayName}
-		class="day js-day"
-		open={open}
-	>
-		<summary class="day__summary">
+		className="day js-day"
+		initiallyOpen={open}
+
+		summaryClass="day__summary"
+		summary={<>
 			<TaskStatusComponent
 				taskId={taskId}
 				dayName={dayTaskInfo.dayName}
@@ -52,10 +54,10 @@ export function DayTaskDetail(props: DayTaskDetailProps): JSX.Element {
 				editButtonTitle="Edit summary"
 				placeholder="Summary"
 			/>
-		</summary>
-
+		</>}
+	>
 		<div class="day__body">
 			<DayTaskNote dayTask={dayTaskInfo} />
 		</div>
-	</details>;
+	</Accordion>;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When loading an Orange Twist instance with a fair amount of content, the initial render can chug for a bit. I've noticed slow tasks taking almost as long as a second during the initial load, mostly taken up by Preact doing DOM comparisons for a large DOM tree.

<!-- Describe your solution -->

This PR adds a new `<Accordion>` component to add some additional logic to disclosures. Now, when initially rendering, disclosures will only render their children if they are open (or when they are opened). However, in order to allow discovery of hidden disclosure content (for example via "Find in page" in Chromium browsers), they will also queue up rendering their children when the main thread is idle, over the next 1.5 seconds.

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
