### PR TITLE
Reduce bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ app/assets/js/dist/
 app/coverage/
 app/service-worker.js
 app/service-worker.js.map
+app/metafile-service-worker.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2024-08-02
+
+### Changed
+
+* Reduced JavaScript bundle sizes
+* Minified CSS
+
 ## [1.5.4] - 2024-08-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.5] - 2024-08-02
+## [1.5.5] - 2024-08-03
 
 ### Changed
 

--- a/app/assets/js/src/components/shared/Markdown/Markdown.tsx
+++ b/app/assets/js/src/components/shared/Markdown/Markdown.tsx
@@ -15,7 +15,7 @@ import { classNames } from 'utils';
 
 import { marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/common';
 
 import {
 	taskLink,

--- a/app/assets/js/src/dev/fps-counter.ts
+++ b/app/assets/js/src/dev/fps-counter.ts
@@ -1,7 +1,5 @@
-import {
-	createElement,
-	startAnimationLoop,
-} from 'utils';
+import { createElement } from 'utils/createElement';
+import { startAnimationLoop } from 'utils/startAnimationLoop';
 
 /**
  * A custom element for displaying frames per second information.

--- a/app/assets/js/src/enhancements.ts
+++ b/app/assets/js/src/enhancements.ts
@@ -7,7 +7,7 @@
  */
 
 import { FpsCounter } from 'dev/fps-counter';
-import { createElement } from 'utils';
+import { createElement } from 'utils/createElement';
 
 if (navigator.serviceWorker) {
 	navigator.serviceWorker.register('/service-worker.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
 		"server": "node --loader ts-node/esm scripts/server.ts",
 
 		"build:js": "concurrently \"tsc\" \"node --loader ts-node/esm scripts/build.ts\"",
-		"build:css": "sass app/assets/scss:app/assets/css",
+		"build:css": "sass app/assets/scss:app/assets/css --style=compressed",
 		"build": "concurrently \"npm:build:*\"",
 
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config=./test/jest.config.js",
 		"test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config=./test/jest.config.js --collectCoverage",
 
 		"watch:js": "node --loader ts-node/esm scripts/build-watch.ts",
-		"watch:css": "sass app/assets/scss:app/assets/css --watch",
+		"watch:css": "sass app/assets/scss:app/assets/css --watch --style=compressed",
 		"watch:test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config=./test/jest.config.js --watch",
 		"watch": "concurrently --kill-others \"tsc --watch --preserveWatchOutput\" \"npm:watch:*\"",
 

--- a/scripts/build-config/main.ts
+++ b/scripts/build-config/main.ts
@@ -30,6 +30,7 @@ export const config: BuildOptions = {
 	outdir: dist,
 	bundle: true,
 	sourcemap: 'linked',
+	metafile: true,
 
 	minify: !isDev,
 	define: {

--- a/scripts/build-config/main.ts
+++ b/scripts/build-config/main.ts
@@ -31,7 +31,6 @@ export const config: BuildOptions = {
 	bundle: true,
 	sourcemap: 'linked',
 	metafile: true,
-
 	minify: !isDev,
 	define: {
 		['__VERSION__']: JSON.stringify(version),

--- a/scripts/build-config/service-worker.ts
+++ b/scripts/build-config/service-worker.ts
@@ -14,5 +14,6 @@ export const config: BuildOptions = {
 	bundle: true,
 	sourcemap: 'linked',
 
+	metafile: true,
 	minify: !isDev,
 };

--- a/scripts/build-config/service-worker.ts
+++ b/scripts/build-config/service-worker.ts
@@ -13,7 +13,6 @@ export const config: BuildOptions = {
 	outfile: `${root}/service-worker.js`,
 	bundle: true,
 	sourcemap: 'linked',
-
 	metafile: true,
 	minify: !isDev,
 };

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -13,6 +13,8 @@ const {
 } = process.env;
 
 const isDev = MODE === 'development';
+
+// Modify this line if you want to generate meta files for prod builds when testing locally:
 const writeMetaFiles = isDev;
 
 const [mainMeta, serviceWorkerMeta] = await Promise.all([

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,9 +1,28 @@
 import * as esbuild from 'esbuild';
+import dotenv from 'dotenv';
+
+import { writeMetaFile } from './utils/index.js';
 
 import { config as mainConfig } from './build-config/main.js';
 import { config as serviceWorkerConfig } from './build-config/service-worker.js';
 
-await Promise.all([
+dotenv.config();
+
+const {
+	MODE,
+} = process.env;
+
+const isDev = MODE === 'development';
+const writeMetaFiles = isDev;
+
+const [mainMeta, serviceWorkerMeta] = await Promise.all([
 	esbuild.build(mainConfig),
 	esbuild.build(serviceWorkerConfig),
 ]);
+
+if (writeMetaFiles) {
+	await Promise.all([
+		writeMetaFile(mainConfig, mainMeta, 'metafile-main.json'),
+		writeMetaFile(serviceWorkerConfig, serviceWorkerMeta, 'metafile-service-worker.json'),
+	]);
+}

--- a/scripts/utils/index.ts
+++ b/scripts/utils/index.ts
@@ -1,0 +1,1 @@
+export { writeMetaFile } from './writeMetaFile.js';

--- a/scripts/utils/writeMetaFile.ts
+++ b/scripts/utils/writeMetaFile.ts
@@ -1,0 +1,29 @@
+import { writeFile } from 'node:fs/promises';
+
+import type { BuildOptions, BuildResult } from 'esbuild';
+
+function getMetaFilePath(config: BuildOptions): string {
+	if (config.outdir) {
+		return config.outdir;
+	}
+
+	if (config.outfile) {
+		// Remove everything starting at the last slash
+		return config.outfile.replace(/\/.+?$/, '');
+	}
+
+	throw new Error('Can\'t determine output path');
+}
+
+export async function writeMetaFile(
+	config: BuildOptions,
+	result: BuildResult<BuildOptions>,
+	filename = 'metafile.json'
+): Promise<void> {
+	if (!result.metafile) {
+		return;
+	}
+
+	const path = `${getMetaFilePath(config)}/${filename}`;
+	return writeFile(path, JSON.stringify(result.metafile, null, '\t'));
+}


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Orange Twist's bundled assets like JavaScript are quite a bit larger than they should be.

<!-- Describe your solution -->
This PR makes a few changes to reduce bundle size:

- Load only the "common" set of languages for `highlight.js`, which was previously taking up about 80% of the bundle size
- Change how some imports are done to make the "enhancements" bundle stay very small
- Add CSS minification to the build

I've also updated the build process to output "metafile" JSON data from esbuild during development, to help with bundle analysis.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
