### PR TITLE
Use cache first service worker strategy in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2024-08-04
+
+### Changed
+
+* Production service worker now uses "cache-first" strategy instead of "network-first"
+
 ## [1.5.5] - 2024-08-03
 
 ### Changed

--- a/app/assets/js/src/define.d.ts
+++ b/app/assets/js/src/define.d.ts
@@ -9,4 +9,4 @@ declare const __VERSION__: string;
 declare const __IS_DEV__: boolean;
 
 /** Whether or not to show the FPS counter (only in development mode). */
-declare const __SHOW_FPS_COUNTER__: boolena;
+declare const __SHOW_FPS_COUNTER__: boolean;

--- a/app/assets/js/src/service-worker/cache/clearCache.ts
+++ b/app/assets/js/src/service-worker/cache/clearCache.ts
@@ -1,0 +1,8 @@
+import { cacheName } from './cacheName';
+
+/**
+ * Remove all entries from the service worker cache.
+ */
+export async function clearCache(): Promise<void> {
+	await caches.delete(cacheName);
+}

--- a/app/assets/js/src/service-worker/cache/clearCache.ts
+++ b/app/assets/js/src/service-worker/cache/clearCache.ts
@@ -1,8 +1,0 @@
-import { cacheName } from './cacheName';
-
-/**
- * Remove all entries from the service worker cache.
- */
-export async function clearCache(): Promise<void> {
-	await caches.delete(cacheName);
-}

--- a/app/assets/js/src/service-worker/cache/index.ts
+++ b/app/assets/js/src/service-worker/cache/index.ts
@@ -1,5 +1,5 @@
 export { addToCache } from './addToCache';
-export { clearCache } from './clearCache';
 export { deleteOldCaches } from './deleteOldCaches';
 export { getCachedResponse } from './getCachedResponse';
 export { populateCache } from './populateCache';
+export { refreshCache } from './refreshCache';

--- a/app/assets/js/src/service-worker/cache/index.ts
+++ b/app/assets/js/src/service-worker/cache/index.ts
@@ -1,4 +1,5 @@
 export { addToCache } from './addToCache';
+export { clearCache } from './clearCache';
 export { deleteOldCaches } from './deleteOldCaches';
 export { getCachedResponse } from './getCachedResponse';
 export { populateCache } from './populateCache';

--- a/app/assets/js/src/service-worker/cache/populateCache.ts
+++ b/app/assets/js/src/service-worker/cache/populateCache.ts
@@ -9,6 +9,7 @@ export async function populateCache(): Promise<void> {
 	cache.addAll([
 		'/',
 		'/task/',
+		'/404.html',
 		'/408.html',
 	]);
 }

--- a/app/assets/js/src/service-worker/cache/refreshCache.ts
+++ b/app/assets/js/src/service-worker/cache/refreshCache.ts
@@ -1,0 +1,50 @@
+import { addToCache } from './addToCache';
+import { cacheName } from './cacheName';
+
+interface RefreshCacheOptions {
+	exceptions?: readonly RequestInfo[];
+}
+
+/**
+ * For each entry that currently exists in the cache, requests fresh data.
+ *
+ * If a good response arrives, cache it. Otherwise, clear that cache entry.
+ */
+export async function refreshCache(options?: RefreshCacheOptions): Promise<void> {
+	const { exceptions } = {
+		exceptions: [],
+		...options,
+	};
+
+	const cache = await caches.open(cacheName);
+
+	const requests = await cache.keys();
+	const promisesToResolve: Promise<unknown>[] = [];
+	requests.forEach((request) => {
+		// Skip exceptions
+		for (const exception of exceptions) {
+			const exceptionUrl = typeof exception === 'string'
+				? exception
+				: String(exception.url);
+
+			if (String(request.url) === exceptionUrl) {
+				return;
+			}
+		}
+
+		// Otherwise, request a fresh response then cache it
+		const responsePromise = fetch(request);
+		responsePromise
+			.then((response) => {
+				promisesToResolve.push(addToCache(request, response));
+			})
+			.catch(() => {
+				// If we couldn't get a new response, clear that entry
+				promisesToResolve.push(cache.delete(request));
+			});
+		promisesToResolve.push(responsePromise);
+	});
+
+	// Don't resolve until the cache is refreshed
+	await Promise.allSettled(promisesToResolve);
+}

--- a/app/assets/js/src/service-worker/cache/refreshCache.ts
+++ b/app/assets/js/src/service-worker/cache/refreshCache.ts
@@ -36,7 +36,13 @@ export async function refreshCache(options?: RefreshCacheOptions): Promise<void>
 		const responsePromise = fetch(request);
 		responsePromise
 			.then((response) => {
-				promisesToResolve.push(addToCache(request, response));
+				if (response.ok) {
+					// If we got a good response, cache it
+					promisesToResolve.push(addToCache(request, response));
+				} else {
+					// Otherwise, clear this entry
+					promisesToResolve.push(cache.delete(request));
+				}
 			})
 			.catch(() => {
 				// If we couldn't get a new response, clear that entry

--- a/app/assets/js/src/service-worker/define.d.ts
+++ b/app/assets/js/src/service-worker/define.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @file This file declares constants that are replaced during the build process.
+ */
+
+/** Whether or not the current build is in development mode. */
+declare const __IS_DEV__: boolean;

--- a/app/assets/js/src/service-worker/error/getFallbackResponse.ts
+++ b/app/assets/js/src/service-worker/error/getFallbackResponse.ts
@@ -1,0 +1,32 @@
+import { getCachedResponse } from '../cache';
+
+/**
+ * Provide a fallback `Response` for when we can't provide a response from the network or the cache.
+ *
+ * Provides a "Request Timeout" error message, either as HTML for document requests or as plain text.
+ */
+export async function getFallbackResponse(request: Request, error: unknown): Promise<Response> {
+	if (request.destination === 'document') {
+		// If the request is for a page, and we don't have a cached
+		// response, try to return a generic network error page
+		const errorResponse = await getCachedResponse(
+			new URL('/408.html', self.location.origin)
+		);
+
+		if (errorResponse) {
+			return new Response(errorResponse.clone().body, {
+				...errorResponse,
+				status: 408, // REQUEST_TIMEOUT
+			});
+		}
+	}
+
+	// Otherwise, return a generic network error in plain text instead
+	const message = error instanceof Error ? error.message : 'Network error';
+	return new Response(message, {
+		status: 408, // REQUEST_TIMEOUT
+		headers: {
+			'Content-Type': 'text/plain',
+		},
+	});
+}

--- a/app/assets/js/src/service-worker/error/index.ts
+++ b/app/assets/js/src/service-worker/error/index.ts
@@ -1,0 +1,1 @@
+export { getFallbackResponse } from './getFallbackResponse';

--- a/app/assets/js/src/service-worker/strategy/cacheFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/cacheFirst.ts
@@ -65,9 +65,10 @@ async function handleNetworkResponse(request: Request, response: Response) {
 		return;
 	}
 
+	// Create a copy so we can consume the original's body
 	const responseToCache = response.clone();
 
-	// Check if a response has changes since it was last cached, and refresh the cache if so
+	// Check if a response has changed since it was last cached, and refresh the cache if so
 	const shouldRefreshCache = await (async () => {
 		const cachedResponse = await getCachedResponse(request);
 		if (!cachedResponse?.body) {

--- a/app/assets/js/src/service-worker/strategy/cacheFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/cacheFirst.ts
@@ -42,7 +42,13 @@ export async function cacheFirst({ request }: FetchEvent): Promise<Response> {
 
 	// If there was no cached response, try to return the network response eventually
 	try {
-		return await networkPromise;
+		const response = await networkPromise;
+		if (response.ok) {
+			return response;
+		} else {
+			// Pass to the cache block to get a fallback response
+			throw new Error(response.statusText);
+		}
 	} catch (error) {
 		// If using the network response failed, provide a fallback
 		return await getFallbackResponse(request, error);

--- a/app/assets/js/src/service-worker/strategy/cacheFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/cacheFirst.ts
@@ -19,7 +19,7 @@ export async function cacheFirst({ preloadResponse, request }: FetchEvent): Prom
 			return preloadedNetworkResponse;
 		}
 
-		return await fetch(request);
+		return fetch(request);
 	})();
 	networkPromise.then(
 		(response) => handleNetworkResponse(request, response)

--- a/app/assets/js/src/service-worker/strategy/cacheFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/cacheFirst.ts
@@ -1,26 +1,35 @@
 import {
 	addToCache,
-	clearCache,
 	getCachedResponse,
+	refreshCache,
 } from '../cache';
 import { getFallbackResponse } from '../error';
 
 /**
  * Return a cached `Response` if possible, while waiting for the network response.
  *
- * If an update is detected from a network response, clear the entire cache so fresh assets will be requested and cached.
+ * If an update is detected from a network response, refresh the entire cache by requesting
+ * a fresh copy of each entry that already exists in the cache. Any entries that fail to be
+ * refreshed in this way, for example due to a network error, will be cleared so fresh assets
+ * will be requested and cached.
+ *
+ * The cache is refreshed asynchronously, without blocking the current request. It's assumed
+ * that responses served during a document load are all requested up front, and will be
+ * retrieved from the cache faster than the cache is able to be refreshed. So long as this
+ * assumption holds, each document load should consist entirely of either stale or fresh assets.
+ *
+ * ---
+ *
+ * This strategy relies on the assumption that all network requests are for static assets, so
+ * if the response of any request has changed then any number of others *may* have changed.
+ *
+ * This strategy also relies less heavily on the assumption that there is a relatively small
+ * number and total size of these static assets, as this affects how heavy the act of refreshing
+ * the cache is.
  */
-export async function cacheFirst({ preloadResponse, request }: FetchEvent): Promise<Response> {
+export async function cacheFirst({ request }: FetchEvent): Promise<Response> {
 	// Initialise the network request immediately, and queue its follow-up action to happen asynchronously
-	const networkPromise = (async () => {
-		// If there is a preloaded response, prefer that
-		const preloadedNetworkResponse = await preloadResponse as unknown;
-		if (preloadedNetworkResponse instanceof Response) {
-			return preloadedNetworkResponse;
-		}
-
-		return fetch(request);
-	})();
+	const networkPromise = fetch(request);
 	networkPromise.then(
 		(response) => handleNetworkResponse(request, response)
 	);
@@ -41,7 +50,7 @@ export async function cacheFirst({ preloadResponse, request }: FetchEvent): Prom
 }
 
 /**
- * Adds a successful response to the cache. If it's changed since it was last cached, also clears the cache.
+ * Adds a successful response to the cache. If it's changed since it was last cached, also refreshes the cache.
  *
  * Ignores unsuccessful responses.
  */
@@ -49,8 +58,8 @@ async function handleNetworkResponse(request: Request, response: Response) {
 	if (response.ok) {
 		const responseToCache = response.clone();
 
-		// Check if a response has changes since it was last cached, and clear the cache if so
-		const shouldClearCache = await (async () => {
+		// Check if a response has changes since it was last cached, and refresh the cache if so
+		const shouldRefreshCache = await (async () => {
 			const cachedResponse = await getCachedResponse(request);
 			if (!cachedResponse?.body) {
 				return false;
@@ -68,9 +77,11 @@ async function handleNetworkResponse(request: Request, response: Response) {
 			return hasChanged;
 		})();
 
-		if (shouldClearCache) {
-			await clearCache();
-		}
 		addToCache(request, responseToCache);
+		if (shouldRefreshCache) {
+			await refreshCache({
+				exceptions: [request],
+			});
+		}
 	}
 }

--- a/app/assets/js/src/service-worker/strategy/cacheFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/cacheFirst.ts
@@ -1,0 +1,76 @@
+import {
+	addToCache,
+	clearCache,
+	getCachedResponse,
+} from '../cache';
+import { getFallbackResponse } from '../error';
+
+/**
+ * Return a cached `Response` if possible, while waiting for the network response.
+ *
+ * If an update is detected from a network response, clear the entire cache so fresh assets will be requested and cached.
+ */
+export async function cacheFirst({ preloadResponse, request }: FetchEvent): Promise<Response> {
+	// Initialise the network request immediately, and queue its follow-up action to happen asynchronously
+	const networkPromise = (async () => {
+		// If there is a preloaded response, prefer that
+		const preloadedNetworkResponse = await preloadResponse as unknown;
+		if (preloadedNetworkResponse instanceof Response) {
+			return preloadedNetworkResponse;
+		}
+
+		return await fetch(request);
+	})();
+	networkPromise.then(
+		(response) => handleNetworkResponse(request, response)
+	);
+
+	// Retrieve a cached response and try to return it
+	const cachedResponse = await getCachedResponse(request);
+	if (cachedResponse) {
+		return cachedResponse;
+	}
+
+	// If there was no cached response, try to return the network response eventually
+	try {
+		return await networkPromise;
+	} catch (error) {
+		// If using the network response failed, provide a fallback
+		return await getFallbackResponse(request, error);
+	}
+}
+
+/**
+ * Adds a successful response to the cache. If it's changed since it was last cached, also clears the cache.
+ *
+ * Ignores unsuccessful responses.
+ */
+async function handleNetworkResponse(request: Request, response: Response) {
+	if (response.ok) {
+		const responseToCache = response.clone();
+
+		// Check if a response has changes since it was last cached, and clear the cache if so
+		const shouldClearCache = await (async () => {
+			const cachedResponse = await getCachedResponse(request);
+			if (!cachedResponse?.body) {
+				return false;
+			}
+
+			const [
+				cachedResponseText,
+				responseText,
+			] = await Promise.all([
+				cachedResponse.text(),
+				response.text(),
+			]);
+			const hasChanged = cachedResponseText !== responseText;
+
+			return hasChanged;
+		})();
+
+		if (shouldClearCache) {
+			await clearCache();
+		}
+		addToCache(request, responseToCache);
+	}
+}

--- a/app/assets/js/src/service-worker/strategy/index.ts
+++ b/app/assets/js/src/service-worker/strategy/index.ts
@@ -1,1 +1,2 @@
+export { cacheFirst } from './cacheFirst';
 export { networkFirst } from './networkFirst';

--- a/app/assets/js/src/service-worker/strategy/networkFirst.ts
+++ b/app/assets/js/src/service-worker/strategy/networkFirst.ts
@@ -1,4 +1,5 @@
 import { addToCache, getCachedResponse } from '../cache';
+import { getFallbackResponse } from '../error';
 
 /**
  * Attempt to return a regular network `Response`, but if something goes
@@ -32,28 +33,7 @@ export async function networkFirst({ preloadResponse, request }: FetchEvent): Pr
 			return cachedResponse;
 		}
 
-		if (request.destination === 'document') {
-			// If the request is for a page, and we don't have a cached
-			// response, try to return a generic network error page
-			const errorResponse = await getCachedResponse(
-				new URL('/408.html', self.location.origin)
-			);
-
-			if (errorResponse) {
-				return new Response(errorResponse.clone().body, {
-					...errorResponse,
-					status: 408, // REQUEST_TIMEOUT
-				});
-			}
-		}
-
-		// Otherwise, return a generic network error in plain text instead
-		const message = error instanceof Error ? error.message : 'Network error';
-		return new Response(message, {
-			status: 408, // REQUEST_TIMEOUT
-			headers: {
-				'Content-Type': 'text/plain',
-			},
-		});
+		// If the request failed and we can't return a cached response, use a fallback
+		return await getFallbackResponse(request, error);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.5",
+	"version": "1.5.6",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",

--- a/scripts/build-config/service-worker.ts
+++ b/scripts/build-config/service-worker.ts
@@ -15,4 +15,7 @@ export const config: BuildOptions = {
 	sourcemap: 'linked',
 	metafile: true,
 	minify: !isDev,
+	define: {
+		['__IS_DEV__']: JSON.stringify(isDev),
+	},
 };


### PR DESCRIPTION
<!-- Describe the problem being solved -->
I've noticed that HTTP responses from GitHub Pages can be a bit slow.

<!-- Describe your solution -->
This PR updates the service worker to use a "cache first" strategy in production. This should speed up response times since it will be faster to access the cache than waiting for the network.

This strategy still makes network requests, and caches those responses for the next time they're requested. If it detects that any of them have changed, it refreshes the entire cache to make sure a fresh copy of everything is available next time, in order to avoid pages loading with a mix of old and new resources while still keeping each load fast.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
