### PR TITLE
Cache help page when initially populating the cache

### DIFF
--- a/app/assets/js/src/service-worker/cache/populateCache.ts
+++ b/app/assets/js/src/service-worker/cache/populateCache.ts
@@ -9,6 +9,7 @@ export async function populateCache(): Promise<void> {
 	cache.addAll([
 		'/',
 		'/task/',
+		'/help/',
 		'/404.html',
 		'/408.html',
 	]);


### PR DESCRIPTION
<!-- Describe the problem being solved -->
I noticed that the "Help" page is not included when initally populating the service worker cache, but it should be.

<!-- Describe your solution -->
This PR updates the list of paths to populate in the cache initially to include the "Help" page.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [ ] ~~A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)~~ I think this doesn't need a separate changelog entry
