### PR TITLE
Improve initial load appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.6] - 2024-08-04
+## [1.5.6] - 2024-08-06
 
 ### Changed
 
 * Production service worker now uses "cache-first" strategy instead of "network-first"
+* Changed appearance of initial rendering to improve perceived speed
 
 ## [1.5.5] - 2024-08-03
 

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -434,7 +434,7 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 				/>
 			</ToolDrawer>
 
-			{children}
+			{!isLoading && children}
 
 			<Footer />
 		</div>

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -42,6 +42,7 @@ import {
 } from 'registers/keyboard-shortcuts';
 
 import {
+	classNames,
 	type DefaultsFor,
 	getCurrentDateDayName,
 	isValidDateString,
@@ -404,38 +405,44 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 			onClose={closeCommandPalette}
 		/>
 
-		<div class="orange-twist">
-			<ToolDrawer side={ToolDrawerPlacement.LEFT}>
-				{
-					backButton &&
+		{!isLoading &&
+			<div
+				class={classNames('orange-twist', {
+					'orange-twist--loading': isLoading,
+				})}
+			>
+				<ToolDrawer side={ToolDrawerPlacement.LEFT}>
+					{
+						backButton &&
+						<IconButton
+							icon="<"
+							title="Back"
+							href="../"
+						/>
+					}
+				</ToolDrawer>
+
+				<h1 class="orange-twist__heading">Orange Twist</h1>
+
+				<ToolDrawer side={ToolDrawerPlacement.RIGHT}>
 					<IconButton
-						icon="<"
-						title="Back"
-						href="../"
+						icon="\"
+						title="Open command palette"
+						onClick={openCommandPalette}
 					/>
-				}
-			</ToolDrawer>
 
-			<h1 class="orange-twist__heading">Orange Twist</h1>
+					<IconButton
+						icon="?"
+						title="Show keyboard shortcuts"
+						onClick={openKeyboardShortcutsModal}
+					/>
+				</ToolDrawer>
 
-			<ToolDrawer side={ToolDrawerPlacement.RIGHT}>
-				<IconButton
-					icon="\"
-					title="Open command palette"
-					onClick={openCommandPalette}
-				/>
+				{children}
 
-				<IconButton
-					icon="?"
-					title="Show keyboard shortcuts"
-					onClick={openKeyboardShortcutsModal}
-				/>
-			</ToolDrawer>
-
-			{!isLoading && children}
-
-			<Footer />
-		</div>
+				<Footer />
+			</div>
+		}
 
 		<KeyboardShortcutModal
 			open={keyboardShortcutsModalOpen}

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -402,44 +402,42 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 			onClose={closeCommandPalette}
 		/>
 
-		{!isLoading &&
-			<div
-				class={classNames('orange-twist', {
-					'orange-twist--loading': isLoading,
-				})}
-			>
-				<ToolDrawer side={ToolDrawerPlacement.LEFT}>
-					{
-						backButton &&
+		<div
+			class={classNames('orange-twist', {
+				'orange-twist--loading': isLoading,
+			})}
+		>
+			<ToolDrawer side={ToolDrawerPlacement.LEFT}>
+				{
+					backButton &&
 						<IconButton
 							icon="<"
 							title="Back"
 							href="../"
 						/>
-					}
-				</ToolDrawer>
+				}
+			</ToolDrawer>
 
-				<h1 class="orange-twist__heading">Orange Twist</h1>
+			<h1 class="orange-twist__heading">Orange Twist</h1>
 
-				<ToolDrawer side={ToolDrawerPlacement.RIGHT}>
-					<IconButton
-						icon="\"
-						title="Open command palette"
-						onClick={openCommandPalette}
-					/>
+			<ToolDrawer side={ToolDrawerPlacement.RIGHT}>
+				<IconButton
+					icon="\"
+					title="Open command palette"
+					onClick={openCommandPalette}
+				/>
 
-					<IconButton
-						icon="?"
-						title="Show keyboard shortcuts"
-						onClick={openKeyboardShortcutsModal}
-					/>
-				</ToolDrawer>
+				<IconButton
+					icon="?"
+					title="Show keyboard shortcuts"
+					onClick={openKeyboardShortcutsModal}
+				/>
+			</ToolDrawer>
 
-				{children}
+			{children}
 
-				<Footer />
-			</div>
-		}
+			<Footer />
+		</div>
 
 		<KeyboardShortcutModal
 			open={keyboardShortcutsModalOpen}

--- a/app/assets/js/src/components/OrangeTwist.tsx
+++ b/app/assets/js/src/components/OrangeTwist.tsx
@@ -394,10 +394,7 @@ export function OrangeTwist(props: OrangeTwistProps): JSX.Element {
 		}}
 	>
 		{
-			__IS_DEV__ && <>
-				<link rel="stylesheet" href="/assets/css/dev.css" />
-				<span class="dev-ribbon">unreleased</span>
-			</>
+			__IS_DEV__ && <span class="dev-ribbon">unreleased</span>
 		}
 
 		<CommandPalette

--- a/app/assets/js/src/enhancements.ts
+++ b/app/assets/js/src/enhancements.ts
@@ -15,6 +15,18 @@ if (navigator.serviceWorker) {
 
 if (__IS_DEV__) {
 	/**
+	 * Insert the extra CSS file for dev CSS.
+	 */
+	const insertDevCss = () => {
+		const cssLink = document.createElement('link');
+		cssLink.rel = 'stylesheet';
+		cssLink.href = '/assets/css/dev.css';
+		cssLink.setAttribute('blocking', 'render');
+
+		document.head.appendChild(cssLink);
+	};
+
+	/**
 	 * Update the document title and favicon to reflect that the app is running in dev mode.
 	 */
 	const displayDevMode = () => {
@@ -40,6 +52,7 @@ if (__IS_DEV__) {
 		document.body.prepend(fpsEl);
 	};
 
+	insertDevCss();
 	displayDevMode();
 	if (__SHOW_FPS_COUNTER__) {
 		displayFramesPerSecond();

--- a/app/assets/scss/components/_orange-twist.scss
+++ b/app/assets/scss/components/_orange-twist.scss
@@ -16,6 +16,10 @@
 	}
 }
 
+.orange-twist--loading {
+	display: none;
+}
+
 .orange-twist__heading {
 	@include typography.heading-1;
 	// Hack to make top of text flush with top of box


### PR DESCRIPTION
<!-- Describe the problem being solved -->
While a page is being loaded, there is a noticeable flash of incomplete markup, rendered before content was loaded from IndexedDB. Additionally, in dev mode the "Unreleased" banner may occasionally appear unstyled initially before quickly getting its styles.

<!-- Describe your solution -->
This PR makes two changes:

- Hide Orange Twist markup with CSS until the initial render with data is complete
- Change the method of inserting `dev.css`

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
