### PR TITLE
Fix issue with two templates with arguments on the same line

### DIFF
--- a/app/assets/js/src/components/shared/Markdown/Markdown.test.tsx
+++ b/app/assets/js/src/components/shared/Markdown/Markdown.test.tsx
@@ -268,5 +268,17 @@ this is the second line`;
 			const content = getByTestId('markdown-content');
 			expect(content).toMatchSnapshot();
 		});
+
+		test('renders two templates with arguments on the same line', () => {
+			const { getByTestId } = render(
+				<Markdown
+					content="{{args|arg0|arg1}} {{args|arg0|arg1}}"
+					data-testid="markdown-content"
+				/>
+			);
+
+			const content = getByTestId('markdown-content');
+			expect(content).toMatchSnapshot();
+		});
 	});
 });

--- a/app/assets/js/src/components/shared/Markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/app/assets/js/src/components/shared/Markdown/__snapshots__/Markdown.test.tsx.snap
@@ -83,6 +83,33 @@ exports[`Markdown renders templates renders message for empty templates 1`] = `
 </div>
 `;
 
+exports[`Markdown renders templates renders two templates with arguments on the same line 1`] = `
+<div
+  class="content"
+  data-testid="markdown-content"
+>
+  <p>
+    <em>
+      arg0
+    </em>
+     
+    <em>
+      arg1
+    </em>
+     
+    <em>
+      arg0
+    </em>
+     
+    <em>
+      arg1
+    </em>
+  </p>
+  
+
+</div>
+`;
+
 exports[`Markdown renders templates with a recognised name 1`] = `
 <div
   class="content"

--- a/app/assets/js/src/components/shared/Markdown/extensions/template.ts
+++ b/app/assets/js/src/components/shared/Markdown/extensions/template.ts
@@ -38,7 +38,7 @@ export const template: TokenizerAndRendererExtension = {
 		// Expression for complete token, from its start
 		// Match a name in double braces, optionally with one or more parameters separated by pipes
 		// e.g. "{{template-name|1|title}}"
-		const rule = /^(\{\{([^{|}]+)(\|(.+))?}})/;
+		const rule = /^(\{\{([^{|}]+)(\|(.+?))?}})/;
 		const match = rule.exec(src);
 		if (!match) {
 			return;


### PR DESCRIPTION
<!-- Describe the problem being solved -->

When rendering two templates with arguments on the same line, a greedy expression combines the second template into the first's arguments.

<!-- Describe your solution -->

This PR makes the `.+` character group in the template regular expression non-greedy by appending an `?` to it.

<!-- List any issues that are resolved by this PR -->
Resolves #186

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
