### PR TITLE
Use CSS field sizing where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2024-12-30
+
+### Changed
+
+* When `field-sizing: content` is supported, Orange Twist uses CSS instead of JS to control the size of notes while they're being edited
+
 ## [1.6.0] - 2024-08-21
 
 ### Added

--- a/app/assets/js/src/components/shared/Note.tsx
+++ b/app/assets/js/src/components/shared/Note.tsx
@@ -54,6 +54,11 @@ interface NoteProps {
 const maxFileSize = 1024 * 1024 * 5; // 5 MB
 
 /**
+ * Whether or not the current browser supports CSS field-sizing.
+ */
+const fieldSizingSupport = CSS.supports('field-sizing', 'content');
+
+/**
  * Display a note as HTML, and provide options to edit
  * it in a textarea as Markdown.
  */
@@ -125,6 +130,11 @@ export function Note(props: NoteProps): JSX.Element {
 	}, [onNoteChange, hasNoteChanged]);
 
 	const updateSpaceholderSize = useCallback((note: string) => {
+		// Prefer using CSS to let the note adjust to its content size
+		if (fieldSizingSupport) {
+			return;
+		}
+
 		const spaceholder = spaceholderRef.current;
 		if (!spaceholder) {
 			return;

--- a/app/assets/scss/components/_note.scss
+++ b/app/assets/scss/components/_note.scss
@@ -19,34 +19,49 @@
 	.content:not(:empty) {
 		padding: var(--_gutter);
 	}
+
+	.content {
+		margin-bottom: 0;
+	}
 }
 
 .note__edit-content {
-	// Using this approach:
-	// https://css-tricks.com/auto-growing-inputs-textareas/
-	display: grid;
-
-	// Stack them on top of each other
-	&::before,
-	textarea {
-		grid-area: 1 / -1;
-
-		@include typography.base-body;
-		padding: var(--_gutter);
+	@supports (field-sizing: content) {
+		textarea {
+			field-sizing: content;
+			width: 100%;
+		}
 	}
 
-	// Simulate content of textarea with visibility hidden, to auto-expand content
-	&::before {
-		content: attr(data-content) " ";
-		white-space-collapse: preserve;
-		word-break: break-word;
-		visibility: hidden;
+	@supports not (field-sizing: content) {
+		// Using this approach:
+		// https://css-tricks.com/auto-growing-inputs-textareas/
+		display: grid;
+
+		// Stack them on top of each other
+		&::before,
+		textarea {
+			grid-area: 1 / -1;
+
+			@include typography.base-body;
+		}
+
+		// Simulate content of textarea with visibility hidden, to auto-expand content
+		&::before {
+			content: attr(data-content) " ";
+			white-space-collapse: preserve;
+			word-break: break-word;
+			visibility: hidden;
+			padding: var(--_gutter);
+		}
 	}
 
 	textarea {
 		@include palette.primary;
 		resize: none;
 		overflow: hidden;
+		display: block;
+		padding: var(--_gutter);
 
 		@include typography.base-body;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -90,7 +90,18 @@ function polyfillBroadcastChannelApi() {
 	window.BroadcastChannel = BroadcastChannel;
 }
 
+/**
+ * jsdom hasn't implemented the CSS API, so replace it with a mocked
+ * version so it won't cause JavaScript errors.
+ */
+function polyfillCSS() {
+	window.CSS = {} as unknown as typeof window.CSS;
+
+	window.CSS.supports = () => true;
+}
+
 polyfillBroadcastChannelApi();
+polyfillCSS();
 
 beforeAll(() => {
 	polyfillDialogElement();


### PR DESCRIPTION
<!-- Describe the problem being solved -->

Orange Twist currently relies on a JavaScript-based solution that has Preact re-render a component after each time a note being edited is changed, down to individual keypresses. This is a relatively low performance solution, which could be achieved using `field-sizing: content` where it is supported.

<!-- Describe your solution -->

This PR adds support for `field-sizing: content` as a progressive enhancement.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
