### PR TITLE
Use anchor positioning for task status options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2024-12-30
+
+### Added
+
+* Where supported, task status options use CSS anchor positioning to try fallback positions and remain within the viewport
+
 ## [1.5.5] - 2024-08-03
 
 ### Changed

--- a/app/assets/js/src/components/tasks/TaskStatusComponent/TaskStatusComponent.tsx
+++ b/app/assets/js/src/components/tasks/TaskStatusComponent/TaskStatusComponent.tsx
@@ -2,6 +2,7 @@ import { h, type JSX } from 'preact';
 import {
 	useCallback,
 	useEffect,
+	useId,
 	useMemo,
 	useRef,
 	useState,
@@ -91,6 +92,9 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 	const enterChangeMode = useCallback(() => {
 		setIsInChangeMode(true);
 	}, []);
+
+	const positionAnchorId = useId();
+	const positionAnchorName = `--taskStatus_${positionAnchorId}`;
 
 	/**
 	 * Update task data to reflect new status.
@@ -190,6 +194,10 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 
 		if (isInChangeMode) {
 			popover.show();
+			// The `opening` attribute is used to adjust z-index
+			popover.setAttribute('opening', '');
+			const animation = animate(popover, CSSKeyframes.APPEAR_SCREEN);
+			animation.finished.then(() => popover.removeAttribute('opening'));
 		} else {
 			const animation = animate(popover, CSSKeyframes.DISAPPEAR_SCREEN);
 			animation.finished.then(() => popover.close());
@@ -231,6 +239,9 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 	return <span
 		class="task-status"
 		ref={rootRef}
+		style={{
+			anchorName: positionAnchorName,
+		}}
 	>
 		{readonly
 			? <IconButton
@@ -256,6 +267,9 @@ export function TaskStatusComponent(props: TaskStatusComponentProps): JSX.Elemen
 			ref={popoverRef}
 			tabindex={-1}
 			inert={!isInChangeMode}
+			style={{
+				positionAnchor: positionAnchorName,
+			}}
 		>
 			<ul
 				class="task-status__options"

--- a/app/assets/scss/components/_day.scss
+++ b/app/assets/scss/components/_day.scss
@@ -9,8 +9,6 @@
 
 .day {
 	margin: spacing.$lg 0;
-
-	isolation: isolate;
 }
 
 .day__summary {
@@ -20,6 +18,12 @@
 	position: sticky;
 	top: 0;
 	z-index: 1;
+	&:has(.task-status__popover[open]) {
+		z-index: 2;
+	}
+	&:has(.task-status__popover[opening]) {
+		z-index: 3;
+	}
 
 	display: flex;
 	gap: spacing.$sm;

--- a/app/assets/scss/components/_task-status.scss
+++ b/app/assets/scss/components/_task-status.scss
@@ -10,12 +10,25 @@
 	position: relative;
 
 	--_gap: #{spacing.$sm};
+
+	&:has(.task-status__popover[open]) {
+		anchor-name: --taskStatus;
+	}
 }
 
 .task-status__popover {
-	position: absolute;
-	bottom: 100%;
-	margin-bottom: spacing.$sm;
+	@supports (position-anchor: --taskStatus) {
+		position: fixed;
+		position-anchor: --taskStatus;
+
+		inset-area: top span-right;
+		position-try-fallbacks: flip-block;
+	}
+	@supports not(position-anchor: --taskStatus) {
+		position: absolute;
+		bottom: 100%;
+	}
+	margin: 0 0 spacing.$sm;
 	z-index: 1;
 
 	&[open] {

--- a/app/assets/scss/components/_task-status.scss
+++ b/app/assets/scss/components/_task-status.scss
@@ -10,30 +10,27 @@
 	position: relative;
 
 	--_gap: #{spacing.$sm};
-
-	&:has(.task-status__popover[open]) {
-		anchor-name: --taskStatus;
-	}
 }
 
 .task-status__popover {
 	@supports (position-anchor: --taskStatus) {
 		position: fixed;
-		position-anchor: --taskStatus;
 
-		inset-area: top span-right;
-		position-try-fallbacks: flip-block;
+		margin: spacing.$xs 0;
+		position-area: top span-right;
+		position-try-fallbacks: flip-block, flip-inline;
 	}
 	@supports not(position-anchor: --taskStatus) {
 		position: absolute;
 		bottom: 100%;
+		margin: 0 0 spacing.$xs;
 	}
-	margin: 0 0 spacing.$sm;
 	z-index: 1;
 
 	&[open] {
-		animation: appearScreen animation.$speed-medium animation.$easing-default;
+		animation: none animation.$speed-medium animation.$easing-default;
 	}
+	// See `_day.scss` for z-index controls based on open/opening status
 
 	// It's not interactive or tabbable, so let it have no focus style
 	&:focus-visible {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.5",
+	"version": "1.6.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Orange Twist currently relies on absolute positioning to place the task status options container. This means it currently always appears above the button that opens it, which can sometimes mean it's not fully visible within the viewport when it's opened.

<!-- Describe your solution -->
This PR adds support for CSS anchor positioning and its `position-try-fallbacks` property, so if there's not enough room for task status options to appear within the viewport then they will be shifted.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
