### PR TITLE
Improve performance of decoding day task keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2024-12-30
+
+### Fixed
+
+* The performance of `decodeDayTaskKey` should be improved, which will hopefully help improve overall performance
+
 ## [1.6.0] - 2024-08-21
 
 ### Added

--- a/app/assets/js/src/data/dayTasks/util/decodeDayTaskKey.ts
+++ b/app/assets/js/src/data/dayTasks/util/decodeDayTaskKey.ts
@@ -13,14 +13,14 @@ import type { DayTaskIdentifier } from '../types/DayTaskIdentifier';
  * @see {@linkcode encodeDayTaskKey} for the inverse operation.
  */
 export function decodeDayTaskKey(key: RegisterKey<typeof dayTasksRegister>): DayTaskIdentifier {
-	const parts = key.match(/^(\d{4}-\d{2}-\d{2})_(\d+)$/);
+	const [dayName, taskId] = key.split('_');
 
-	if (parts === null) {
+	if (!(dayName && taskId)) {
 		throw new Error(`Invalid day task key ${key}`);
 	}
 
 	return {
-		dayName: parts[1],
-		taskId: Number(parts[2]),
+		dayName,
+		taskId: Number(taskId),
 	};
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
With a lot of data, I've noticed some performance issues occasionally. Based on performance profiling in Chrome, it looks like `decodeDayTaskKey` may be a contributor. This currently uses `String.match` and a regular expression to convert an encoded day task key string into an object.

<!-- Describe your solution -->
Because day task keys are predictably in the format `YYYY-MM-DD_123`, this solution just splits them at the `_` character. That should be safe so long as no one manually edits a file before importing it, though if there's an invalid key then that day task would just never appear.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
