### PR TITLE
Update handling of environment variables during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.1] - 2024-12-30
+## [1.6.1] - 2025-01-03
 
 ### Added
 
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 * When `field-sizing: content` is supported, Orange Twist uses CSS instead of JS to control the size of notes while they're being edited
+* When running Orange Twist locally without a `.env` file, one will be created automatically
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ An example `.env` file you can use for development is:
 ```
 MODE = "development"
 PORT = "8080"
+SHOW_FPS = "false"
 ```
 
 This file is intended to differ from environment to environment, so it is ignored by Git.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.5.3",
+	"version": "1.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.5.3",
+			"version": "1.6.1",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.10.0",

--- a/scripts/build-config/main.ts
+++ b/scripts/build-config/main.ts
@@ -1,16 +1,16 @@
 import type { BuildOptions } from 'esbuild';
-import dotenv from 'dotenv';
 
+import { getEnv } from '../utils/index.js';
 import { dist, src } from './paths.js';
 
 import packageJson from '../../package.json' with { type: 'json' };
 
-dotenv.config();
+const env = getEnv();
 
 const {
 	MODE,
 	SHOW_FPS,
-} = process.env;
+} = env;
 const isDev = MODE === 'development';
 const showFps = Boolean(SHOW_FPS && SHOW_FPS !== 'false');
 

--- a/scripts/build-config/service-worker.ts
+++ b/scripts/build-config/service-worker.ts
@@ -1,11 +1,11 @@
 import type { BuildOptions } from 'esbuild';
-import dotenv from 'dotenv';
 
+import { getEnv } from '../utils/index.js';
 import { root, src } from './paths.js';
 
-dotenv.config();
+const env = getEnv();
 
-const { MODE } = process.env;
+const { MODE } = env;
 const isDev = MODE === 'development';
 
 export const config: BuildOptions = {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,16 +1,18 @@
 import * as esbuild from 'esbuild';
-import dotenv from 'dotenv';
 
-import { writeMetaFile } from './utils/index.js';
+import {
+	getEnv,
+	writeMetaFile,
+} from './utils/index.js';
 
 import { config as mainConfig } from './build-config/main.js';
 import { config as serviceWorkerConfig } from './build-config/service-worker.js';
 
-dotenv.config();
+const env = getEnv();
 
 const {
 	MODE,
-} = process.env;
+} = env;
 
 const isDev = MODE === 'development';
 

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -1,15 +1,20 @@
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import dotenv from 'dotenv';
 import express from 'express';
+
+import { getEnv } from './utils/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-dotenv.config();
 const app = express();
 
-const port = process.env.PORT;
+const env = getEnv();
+const port = Number(env.PORT);
+
+if (isNaN(port)) {
+	throw new Error('Cannot listen to NaN port');
+}
 
 app.use(express.static('app'));
 

--- a/scripts/utils/getEnv.ts
+++ b/scripts/utils/getEnv.ts
@@ -1,0 +1,25 @@
+import { writeFileSync } from 'node:fs';
+
+import dotenv from 'dotenv';
+
+const defaultEnv = `MODE = "development"
+PORT = "8080"
+SHOW_FPS = "false"`;
+
+function init() {
+	try {
+		// If no .env file exists, create one first
+		writeFileSync('.env', defaultEnv, { flag: 'wx' });
+		console.log('Creating default .env file');
+	} catch (e) {
+		// If a .env file exists, just continue
+	}
+
+	dotenv.config();
+}
+
+export function getEnv(): Partial<Record<string, string>> {
+	init();
+
+	return process.env;
+}

--- a/scripts/utils/index.ts
+++ b/scripts/utils/index.ts
@@ -1,1 +1,2 @@
+export { getEnv } from './getEnv.js';
 export { writeMetaFile } from './writeMetaFile.js';


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When initially running Orange Twist locally, if there is no `.env` file, the server will attempt to run on port `undefined`.

<!-- Describe your solution -->
This PR refactors the handling of environment variables to rely on a `getEnv` function. If no `.env` file exists when this function is called, it will create one.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
