### PR TITLE
Memoise `Day` component to improve performance when re-rendering `DaysList`

### DIFF
--- a/app/assets/js/src/components/days/Day.tsx
+++ b/app/assets/js/src/components/days/Day.tsx
@@ -1,5 +1,6 @@
 import { h, type JSX } from 'preact';
 import { useCallback } from 'preact/hooks';
+import { memo } from 'preact/compat';
 
 import { Command } from 'types/Command';
 import { fireCommand } from 'registers/commands';
@@ -24,7 +25,7 @@ interface DayProps {
 /**
  * Renders a day, including its notes and tasks, in a disclosure.
  */
-export const Day = (props: DayProps): JSX.Element => {
+export const Day = memo((props: DayProps): JSX.Element => {
 	const {
 		day,
 		open,
@@ -81,4 +82,4 @@ export const Day = (props: DayProps): JSX.Element => {
 			>Add new task</Button>
 		</div>
 	</Accordion>;
-};
+});

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -19,7 +19,7 @@ import { Day } from './Day';
 /**
  * Renders a list of days.
  */
-export function DayList(): JSX.Element {
+export function DaysList(): JSX.Element {
 	const unsortedDays = useAllDayInfo();
 
 	const { isLoading } = useContext(OrangeTwistContext);

--- a/app/assets/js/src/pages/main.tsx
+++ b/app/assets/js/src/pages/main.tsx
@@ -1,7 +1,7 @@
 import { h, render } from 'preact';
 
 import { OrangeTwist } from 'components/OrangeTwist';
-import { DayList } from 'components/days/DaysList';
+import { DaysList } from 'components/days/DaysList';
 import { UnfinishedTaskList } from 'components/tasks/UnfinishedTaskList';
 import { CompletedTaskList } from 'components/tasks/CompletedTaskList';
 
@@ -11,7 +11,7 @@ if (main === null) {
 }
 
 render(<OrangeTwist>
-	<DayList />
+	<DaysList />
 
 	<UnfinishedTaskList />
 


### PR DESCRIPTION
<!-- Describe the problem being solved -->
When performing certain tasks on the main page, such as reordering a day's tasks, it causes the entire `DaysList` component to be re-rendered. This, in turn, currently cascades down the entire component tree and causes all descendents to be re-rendered as well, which is slow.

<!-- Describe your solution -->
This PR wraps the `Day` component in `memo`, which requires the addition of `preact/compat`.

In the future, I should investigate using [Preact's signals](https://preactjs.com/blog/introducing-signals/) instead of this React-inspired `memo` API.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
