### PR TITLE
Improve dialog performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+* Previous and future days (outside a window of 3 behind and 3 ahead of the current day) are hidden by default. These, and finished tasks, are now completely removed from the DOM when their sections are unhidden, in order to improve UI performance
 * No more than one "Saved" message will display at a time
 * Added additional context to some alert messages
 

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -14,7 +14,7 @@ import { getCurrentDateDayName } from 'utils';
 import { useAllDayInfo } from 'data';
 
 import { OrangeTwistContext } from '../OrangeTwistContext';
-import { Button } from '../shared';
+import { Accordion, Button } from '../shared';
 import { Day } from './Day';
 
 /**
@@ -71,11 +71,13 @@ export function DaysList(): JSX.Element {
 		)}
 
 		{previousDays.length > 0 &&
-			<details class="orange-twist__section" onToggle={onPreviousDaysToggle}>
-				<summary>
+			<Accordion
+				class="orange-twist__section"
+				summary={
 					<h2 class="orange-twist__title">Previous days</h2>
-				</summary>
-
+				}
+				onToggle={onPreviousDaysToggle}
+			>
 				{previousDaysOpen &&
 					previousDays.map(((day) => (
 						<Day
@@ -84,14 +86,16 @@ export function DaysList(): JSX.Element {
 						/>
 					)))
 				}
-			</details>
+			</Accordion>
 		}
 
-		<details class="orange-twist__section" open>
-			<summary>
+		<Accordion
+			class="orange-twist__section"
+			summary={
 				<h2 class="orange-twist__title">Days</h2>
-			</summary>
-
+			}
+			open
+		>
 			{currentDays.map((day) => (
 				<Day
 					key={day.name}
@@ -99,14 +103,16 @@ export function DaysList(): JSX.Element {
 					open={day.name === currentDayName}
 				/>
 			))}
-		</details>
+		</Accordion>
 
 		{futureDays.length > 0 &&
-			<details class="orange-twist__section" onToggle={onFutureDaysToggle}>
-				<summary>
+			<Accordion
+				class="orange-twist__section"
+				summary={
 					<h2 class="orange-twist__title">Future days</h2>
-				</summary>
-
+				}
+				onToggle={onFutureDaysToggle}
+			>
 				{futureDaysOpen &&
 					futureDays.map(((day) => (
 						<Day
@@ -115,7 +121,7 @@ export function DaysList(): JSX.Element {
 						/>
 					)))
 				}
-			</details>
+			</Accordion>
 		}
 
 		<Button

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -3,6 +3,7 @@ import {
 	useCallback,
 	useContext,
 	useMemo,
+	useState,
 } from 'preact/hooks';
 
 import { Command } from 'types/Command';
@@ -47,22 +48,75 @@ export function DaysList(): JSX.Element {
 		[days, currentDayName]
 	);
 
-	return <section class="orange-twist__section">
-		<h2 class="orange-twist__title">Days</h2>
+	// Display a window of 7 days, collapse previous and future days
+	const previousDays = days.slice(0, expandedDayIndex - 4);
+	const [previousDaysOpen, setPreviousDaysOpen] = useState(false);
+	const onPreviousDaysToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
+		setPreviousDaysOpen(event.currentTarget.open);
+	}, []);
 
+	const currentDays = days.slice(expandedDayIndex - 3, expandedDayIndex + 4);
+
+	const futureDays = days.slice(expandedDayIndex + 5);
+	const [futureDaysOpen, setFutureDaysOpen] = useState(false);
+	const onFutureDaysToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
+		setFutureDaysOpen(event.currentTarget.open);
+	}, []);
+
+	return <section class="orange-twist__section">
 		{!isLoading && days.length <= 1 && (
 			<div class="content">
 				<p>If you need help getting started, try <a href="/help">the help page</a>.</p>
 			</div>
 		)}
 
-		{days.map((day, i) => (
-			<Day
-				key={day.name}
-				day={day}
-				open={i === expandedDayIndex}
-			/>
-		))}
+		{previousDays.length > 0 &&
+			<details class="orange-twist__section" onToggle={onPreviousDaysToggle}>
+				<summary>
+					<h2 class="orange-twist__title">Previous days</h2>
+				</summary>
+
+				{previousDaysOpen &&
+					previousDays.map(((day) => (
+						<Day
+							key={day.name}
+							day={day}
+						/>
+					)))
+				}
+			</details>
+		}
+
+		<details class="orange-twist__section" open>
+			<summary>
+				<h2 class="orange-twist__title">Days</h2>
+			</summary>
+
+			{currentDays.map((day) => (
+				<Day
+					key={day.name}
+					day={day}
+					open={day.name === currentDayName}
+				/>
+			))}
+		</details>
+
+		{futureDays.length > 0 &&
+			<details class="orange-twist__section" onToggle={onFutureDaysToggle}>
+				<summary>
+					<h2 class="orange-twist__title">Future days</h2>
+				</summary>
+
+				{futureDaysOpen &&
+					futureDays.map(((day) => (
+						<Day
+							key={day.name}
+							day={day}
+						/>
+					)))
+				}
+			</details>
+		}
 
 		<Button
 			onClick={useCallback(() => fireCommand(Command.DAY_ADD_NEW), [])}

--- a/app/assets/js/src/components/shared/Accordion.tsx
+++ b/app/assets/js/src/components/shared/Accordion.tsx
@@ -15,6 +15,7 @@ interface AccordionProps {
 
 	summary: string | JSX.Element;
 	summaryClass?: string;
+	onToggle?: (event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => void;
 
 	children: ComponentChildren;
 }
@@ -25,6 +26,7 @@ export function Accordion(props: AccordionProps): JSX.Element {
 
 		summary,
 		summaryClass,
+		onToggle,
 
 		children,
 	} = props;
@@ -76,7 +78,10 @@ export function Accordion(props: AccordionProps): JSX.Element {
 	const handleToggle: JSX.GenericEventHandler<HTMLDetailsElement> = useCallback((e) => {
 		const detailsEl = e.currentTarget;
 		setIsOpen(detailsEl.open);
-	}, []);
+		if (onToggle) {
+			onToggle(e);
+		}
+	}, [onToggle]);
 
 	return <details
 		class={className}

--- a/app/assets/js/src/components/tasks/CompletedTaskList.test.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.test.tsx
@@ -102,7 +102,7 @@ describe('CompletedTaskList', () => {
 
 	test('renders all completed tasks', () => {
 		jest.useFakeTimers();
-		const { queryByText } = render(<CompletedTaskList />);
+		const { queryByText } = render(<CompletedTaskList open />);
 
 		// Wait for idle rendering to complete
 		act(() => jest.advanceTimersByTime(1500));
@@ -118,7 +118,7 @@ describe('CompletedTaskList', () => {
 
 	test('renders completed tasks in reverse order of completion', () => {
 		jest.useFakeTimers();
-		const { queryAllByText } = render(<CompletedTaskList />);
+		const { queryAllByText } = render(<CompletedTaskList open />);
 
 		// Wait for idle rendering to complete
 		act(() => jest.advanceTimersByTime(1500));

--- a/app/assets/js/src/components/tasks/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.tsx
@@ -1,5 +1,5 @@
 import { h, type JSX } from 'preact';
-import { useCallback } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
 import {
@@ -10,42 +10,58 @@ import {
 import { Accordion } from 'components/shared';
 import { TaskList } from './TaskList';
 
+interface CompletedTaskListProps {
+	open?: boolean;
+}
+
 /**
  * Renders a list of all completed tasks inside a disclosure.
  */
-export function CompletedTaskList(): JSX.Element | null {
+export function CompletedTaskList(props: CompletedTaskListProps): JSX.Element | null {
+	const [listOpen, setListOpen] = useState(props.open);
+	const onListToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
+		setListOpen(event.currentTarget.open);
+	}, []);
+
+	const matcher = useCallback(
+		({ status }: TaskInfo) => CompletedTaskStatuses.has(status),
+		[]
+	);
+
+	const sorter = useCallback(
+		(taskA: TaskInfo, taskB: TaskInfo): number => {
+			// First, sort by last updated date, with more recent tasks first
+			const dayTasksA = getAllDayTaskInfo({ taskId: taskA.id });
+			const dayTasksB = getAllDayTaskInfo({ taskId: taskB.id });
+
+			const lastUpdatedA = dayTasksA.at(-1)?.dayName ?? '0001-01-01';
+			const lastUpdatedB = dayTasksB.at(-1)?.dayName ?? '0001-01-01';
+
+			const comparison = lastUpdatedB.localeCompare(lastUpdatedA);
+
+			if (comparison !== 0) {
+				return comparison;
+			}
+
+			// Then, sort by sort index
+			return taskA.sortIndex - taskB.sortIndex;
+		},
+		[]
+	);
+
 	return <Accordion
 		class="orange-twist__section"
 		summary={
 			<h2 class="orange-twist__title">Completed tasks</h2>
 		}
+		onToggle={onListToggle}
 	>
-		<TaskList
-			matcher={useCallback(
-				({ status }: TaskInfo) => CompletedTaskStatuses.has(status),
-				[]
-			)}
-			sorter={useCallback(
-				(taskA: TaskInfo, taskB: TaskInfo): number => {
-					// First, sort by last updated date, with more recent tasks first
-					const dayTasksA = getAllDayTaskInfo({ taskId: taskA.id });
-					const dayTasksB = getAllDayTaskInfo({ taskId: taskB.id });
-
-					const lastUpdatedA = dayTasksA.at(-1)?.dayName ?? '0001-01-01';
-					const lastUpdatedB = dayTasksB.at(-1)?.dayName ?? '0001-01-01';
-
-					const comparison = lastUpdatedB.localeCompare(lastUpdatedA);
-
-					if (comparison !== 0) {
-						return comparison;
-					}
-
-					// Then, sort by sort index
-					return taskA.sortIndex - taskB.sortIndex;
-				},
-				[]
-			)}
-			className="orange-twist__task-list"
-		/>
+		{listOpen &&
+			<TaskList
+				matcher={matcher}
+				sorter={sorter}
+				className="orange-twist__task-list"
+			/>
+		}
 	</Accordion>;
 }

--- a/app/assets/js/src/components/tasks/CompletedTaskList.tsx
+++ b/app/assets/js/src/components/tasks/CompletedTaskList.tsx
@@ -1,5 +1,9 @@
 import { h, type JSX } from 'preact';
-import { useCallback, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+	useState,
+} from 'preact/hooks';
 
 import { CompletedTaskStatuses } from 'types/TaskStatus';
 import {
@@ -19,6 +23,7 @@ interface CompletedTaskListProps {
  */
 export function CompletedTaskList(props: CompletedTaskListProps): JSX.Element | null {
 	const [listOpen, setListOpen] = useState(props.open);
+
 	const onListToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
 		setListOpen(event.currentTarget.open);
 	}, []);
@@ -49,12 +54,18 @@ export function CompletedTaskList(props: CompletedTaskListProps): JSX.Element | 
 		[]
 	);
 
+	// Update list open state if prop changes
+	useEffect(() => {
+		setListOpen(props.open);
+	}, [props.open]);
+
 	return <Accordion
 		class="orange-twist__section"
 		summary={
 			<h2 class="orange-twist__title">Completed tasks</h2>
 		}
 		onToggle={onListToggle}
+		open={listOpen}
 	>
 		{listOpen &&
 			<TaskList

--- a/app/assets/scss/components/_day.scss
+++ b/app/assets/scss/components/_day.scss
@@ -25,12 +25,14 @@
 		z-index: 3;
 	}
 
-	display: flex;
-	gap: spacing.$sm;
-	align-items: center;
+	& {
+		display: flex;
+		gap: spacing.$sm;
+		align-items: center;
 
-	@include layout.bp-small {
-		flex-wrap: wrap;
+		@include layout.bp-small {
+			flex-wrap: wrap;
+		}
 	}
 }
 

--- a/app/assets/scss/components/_task-status.scss
+++ b/app/assets/scss/components/_task-status.scss
@@ -25,16 +25,19 @@
 		bottom: 100%;
 		margin: 0 0 spacing.$xs;
 	}
-	z-index: 1;
 
-	&[open] {
-		animation: none animation.$speed-medium animation.$easing-default;
-	}
-	// See `_day.scss` for z-index controls based on open/opening status
+	& {
+		z-index: 1;
 
-	// It's not interactive or tabbable, so let it have no focus style
-	&:focus-visible {
-		outline: none;
+		&[open] {
+			animation: none animation.$speed-medium animation.$easing-default;
+		}
+		// See `_day.scss` for z-index controls based on open/opening status
+
+		// It's not interactive or tabbable, so let it have no focus style
+		&:focus-visible {
+			outline: none;
+		}
 	}
 }
 

--- a/app/assets/scss/sub-components/_drag-list.scss
+++ b/app/assets/scss/sub-components/_drag-list.scss
@@ -37,6 +37,7 @@
 		display: grid;
 		place-content: center;
 		overflow: hidden;
+		align-self: stretch;
 
 		// Force white space in ::before content to break
 		width: var(--_handle-width);


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Particularly when using Orange Twist on Firefox for Android, with a lot of data leading a large DOM, on the main page it can sometimes take a long time (several seconds) to open the task status dialog.

<!-- Describe your solution -->
This PR updates the days list to display a window of 7 days (3 behind and 3 ahead of the current day) and collapse the others into "Previous days" and "Future days" sections. When these sections are closed, their contents are removed from the DOM.

I've also updated the completed tasks list to remove its contents from the DOM when closed.

This will have a negative impact on "Find in page" on Chrome, requiring these sections to be opened first. But hopefully the significantly smaller DOM should improve performance and largely uncouple it from the total size of all data in Orange Twist.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
