### PR TITLE
Fixed missing days in days list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2025-02-01
+
+### Fixed
+
+* The most recent "Past day" and closest "Future day" are no longer missing from their respective sections.
+
 ## [1.6.2] - 2025-01-23
 
 ### Changed

--- a/app/assets/js/src/components/days/DaysList.tsx
+++ b/app/assets/js/src/components/days/DaysList.tsx
@@ -49,7 +49,7 @@ export function DaysList(): JSX.Element {
 	);
 
 	// Display a window of 7 days, collapse previous and future days
-	const previousDays = days.slice(0, expandedDayIndex - 4);
+	const previousDays = days.slice(0, expandedDayIndex - 3);
 	const [previousDaysOpen, setPreviousDaysOpen] = useState(false);
 	const onPreviousDaysToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
 		setPreviousDaysOpen(event.currentTarget.open);
@@ -57,7 +57,7 @@ export function DaysList(): JSX.Element {
 
 	const currentDays = days.slice(expandedDayIndex - 3, expandedDayIndex + 4);
 
-	const futureDays = days.slice(expandedDayIndex + 5);
+	const futureDays = days.slice(expandedDayIndex + 4);
 	const [futureDaysOpen, setFutureDaysOpen] = useState(false);
 	const onFutureDaysToggle = useCallback((event: JSX.TargetedEvent<HTMLDetailsElement, Event>) => {
 		setFutureDaysOpen(event.currentTarget.open);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.6.2",
+			"version": "1.6.3",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
One day was missing at the ends of the "Past days" and "Future days" sections.

<!-- Describe your solution -->
This PR updates the numbers used when slicing up the array of days so that nothing is excluded.

<!-- List any issues that are resolved by this PR -->
Resolves #207 

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
