### PR TITLE
Z index fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-03-19
+
+### Fixed
+
+* Fixed z-index issues with day headers
+
 ## [1.8.1] - 2026-03-15
 
 ### Changed

--- a/app/assets/scss/components/_day.scss
+++ b/app/assets/scss/components/_day.scss
@@ -19,6 +19,7 @@
 
 	position: sticky;
 	top: 0;
+	z-index: 1;
 
 	& {
 		display: flex;
@@ -37,6 +38,9 @@
 	grid-template-columns: minmax(0, 1fr);
 	gap: spacing.$md;
 	padding-top: spacing.$md;
+
+	// Create a stacking context to ensure body content doesn't break out in front of the summary
+	isolation: isolate;
 }
 
 .day__heading {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "orange-twist",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "orange-twist",
-			"version": "1.8.1",
+			"version": "1.8.2",
 			"license": "Hippocratic-2.1",
 			"dependencies": {
 				"highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orange-twist",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "A task management tool designed for my personal style of working.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Version 1.8.1 introduced a z-index bug where day headers were going behind other UI elements they should have appeared in front of.

<!-- Describe your solution -->
This PR adds a `z-index` rule to day headers, and creates a stacking context around their body so nothing can appear in front and clip them.

<!-- List any issues that are resolved by this PR -->
Resolves #241

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
