### PR TITLE
Save task notes on their own

### DIFF
--- a/app/assets/js/src/components/OrangeTwist/useCommandDataSave.tsx
+++ b/app/assets/js/src/components/OrangeTwist/useCommandDataSave.tsx
@@ -9,6 +9,7 @@ import {
 } from 'data';
 
 import { Command } from 'types/Command';
+import type { SaveAction } from 'types/SaveAction';
 import { registerCommand, useCommand } from 'registers/commands';
 import {
 	KeyboardShortcutName,
@@ -16,6 +17,7 @@ import {
 	useKeyboardShortcut,
 } from 'registers/keyboard-shortcuts';
 
+import { SaveHelper } from 'database';
 import type { PersistApi } from 'persist';
 import { syncUpdate } from 'sync';
 
@@ -29,10 +31,16 @@ export interface UseCommandDataSaveOptions {
 	persist: PersistApi;
 }
 
+let saveHelper: SaveHelper;
+
 /**
  * Register the "Save data" command and its keyboard shortcut.
  */
 export function useCommandDataSave({ persist }: UseCommandDataSaveOptions): void {
+	useEffect(() => {
+		saveHelper = saveHelper ?? new SaveHelper();
+	}, []);
+
 	useEffect(() => {
 		registerCommand(Command.DATA_SAVE, { name: 'Save data' });
 	}, []);
@@ -49,20 +57,16 @@ export function useCommandDataSave({ persist }: UseCommandDataSaveOptions): void
 	 * Save all data, while giving the user feedback.
 	 */
 	const saveData = useCallback(
-		async () => {
+		async (saveActions?: readonly SaveAction[]) => {
 			const id = 'saving';
 
 			ui.alert(<>
 				<span>Saving...</span>
 				<Loader immediate />
 			</>, { id, duration: null });
+
 			try {
-				await Promise.all([
-					saveTasks(persist),
-					saveDays(persist),
-					saveDayTasks(persist),
-					saveTemplates(persist),
-				]);
+				await processSaveActions(persist, saveActions);
 				ui.alert('Saved', {
 					duration: 2000,
 					id,
@@ -84,4 +88,23 @@ export function useCommandDataSave({ persist }: UseCommandDataSaveOptions): void
 	useCommand(Command.DATA_SAVE, saveData);
 
 	useKeyboardShortcut(KeyboardShortcutName.DATA_SAVE, Command.DATA_SAVE);
+}
+
+/**
+ * Glue logic for handling both legacy "save all" behaviour, and new {@linkcode SaveAction} processing behaviour.
+ */
+async function processSaveActions(persist: PersistApi, saveActions?: readonly SaveAction[]): Promise<void> {
+	// For the legacy "save all" action, save each register via the PersistApi
+	if (typeof saveActions === 'undefined') {
+		await Promise.all([
+			saveTasks(persist),
+			saveDays(persist),
+			saveDayTasks(persist),
+			saveTemplates(persist),
+		]);
+		return;
+	}
+
+	// Otherwise, process each save action
+	await saveHelper.save(saveActions);
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -15,6 +15,7 @@ import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import type { MarkdownApi } from 'components/shared/Markdown';
 import { Note } from 'components/shared';
+import { SaveType } from 'types/SaveAction';
 
 interface TaskNoteProps {
 	task: Readonly<TaskInfo>;
@@ -24,15 +25,28 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 	const { task } = props;
 
 	const { isLoading } = useContext(OrangeTwistContext);
+	/** Keep a reference to the note for immediate saving before re-renredering. */
+	const noteRef = useRef(task.note);
+	// Make sure to update the ref if the task note changes from other sources
+	useEffect(() => {
+		noteRef.current = task.note;
+	}, [task.note]);
 
 	const setTaskNote = useCallback(
 		(note: string) => {
+			noteRef.current = note;
 			setTaskInfo(task.id, { note });
 		},
 		[task.id]
 	);
 
-	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
+	const saveChanges = useCallback(() => {
+		fireCommand(Command.DATA_SAVE, [{
+			type: SaveType.TASK_NOTE,
+			task: task.id,
+			note: noteRef.current,
+		}]);
+	}, [task.id]);
 
 	const markdownApiRef = useRef<MarkdownApi | null>(null);
 	// When data is finished loading re-render Markdown

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
@@ -1,0 +1,59 @@
+import {
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+
+import { SaveType } from 'types/SaveAction';
+
+import { createTestData } from '../test-utils';
+import { getDatabase } from '../utils';
+import { ObjectStoreName } from '../metadata';
+import { getTaskInternal } from '../internal';
+
+import { SaveHelper } from './SaveHelper';
+
+describe('SaveHelper', () => {
+	let db: IDBDatabase;
+	let saveHelper: SaveHelper;
+
+	beforeEach(async () => {
+		await createTestData();
+		db = await getDatabase();
+		saveHelper = new SaveHelper();
+	});
+
+	test('saves task notes', async () => {
+		let readTransaction = db.transaction([
+			ObjectStoreName.TASK,
+		], 'readonly');
+		const beforeTask1 = await getTaskInternal(readTransaction, 1);
+		const beforeTask2 = await getTaskInternal(readTransaction, 2);
+
+		expect(beforeTask1?.note).toBe('Test task 1 note');
+		expect(beforeTask2?.note).toBe('Test task 2 note');
+
+		await saveHelper.save([
+			{
+				type: SaveType.TASK_NOTE,
+				task: 1,
+				note: 'New note 1',
+			},
+			{
+				type: SaveType.TASK_NOTE,
+				task: 2,
+				note: 'New note 2',
+			},
+		]);
+
+		readTransaction = db.transaction([
+			ObjectStoreName.TASK,
+		], 'readonly');
+		const afterTask1 = await getTaskInternal(readTransaction, 1);
+		const afterTask2 = await getTaskInternal(readTransaction, 2);
+
+		expect(afterTask1?.note).toBe('New note 1');
+		expect(afterTask2?.note).toBe('New note 2');
+	});
+});

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.ts
@@ -1,0 +1,69 @@
+import { SaveType, type SaveAction } from 'types/SaveAction';
+import { assertAllUnionMembersHandled } from 'utils';
+
+import { ObjectStoreName } from '../metadata';
+import { getDatabase } from '../utils';
+import { updateTaskInternal } from 'database/internal';
+
+/**
+ * A helper class for managing database save actions.
+ */
+export class SaveHelper {
+	constructor() {}
+
+	/**
+	 * Process any number of {@linkcode SaveAction}s.
+	 */
+	async save(actions: readonly SaveAction[]): Promise<void> {
+		if (actions.length === 0) {
+			return;
+		}
+
+		const objectStores = this.#gatherTransactionRequirements(actions);
+		const db = await getDatabase();
+		const transaction = db.transaction(objectStores, 'readwrite');
+
+		for (const action of actions) {
+			if (action.type === SaveType.TASK_NOTE) {
+				this.#saveTaskNote(action, transaction);
+			} else {
+				assertAllUnionMembersHandled(action.type);
+			}
+		}
+	}
+
+	/**
+	 * Save the note of a single task.
+	 */
+	async #saveTaskNote(
+		action: Extract<
+			SaveAction, { type: typeof SaveType.TASK_NOTE; }
+		>,
+		transaction: IDBTransaction
+	): Promise<void> {
+		await updateTaskInternal(transaction, {
+			id: action.task,
+			note: action.note,
+		});
+	}
+
+	/**
+	 * For a given set of {@linkcode SaveAction}s, gather the required object stores needed to process them all.
+	 */
+	#gatherTransactionRequirements(
+		actions: readonly SaveAction[]
+	): Iterable<ObjectStoreName> {
+		// Gather requirements
+		const objectStores = new Set<ObjectStoreName>();
+		for (const action of actions) {
+			if (action.type === SaveType.TASK_NOTE) {
+				objectStores.add(ObjectStoreName.TASK);
+				objectStores.add(ObjectStoreName.STATUS);
+			} else {
+				assertAllUnionMembersHandled(action.type);
+			}
+		}
+
+		return Array.from(objectStores);
+	}
+}

--- a/app/assets/js/src/database/SaveHelper/index.ts
+++ b/app/assets/js/src/database/SaveHelper/index.ts
@@ -1,0 +1,1 @@
+export { SaveHelper } from './SaveHelper';

--- a/app/assets/js/src/database/index.ts
+++ b/app/assets/js/src/database/index.ts
@@ -1,1 +1,2 @@
 export { adapterV1, dbV1 } from './adapterV1';
+export { SaveHelper } from './SaveHelper';

--- a/app/assets/js/src/database/internal/updateDayTaskByDayAndTaskInternal.ts
+++ b/app/assets/js/src/database/internal/updateDayTaskByDayAndTaskInternal.ts
@@ -1,6 +1,6 @@
 import type { OptionalExcept } from 'utils';
 
-import { ObjectStoreName } from '../metadata';
+import type { ObjectStoreName } from '../metadata';
 import type { DatabaseData } from '../types';
 
 import { getDayTaskForDayAndTaskInternal } from './getDayTaskForDayAndTaskInternal';
@@ -24,8 +24,6 @@ export async function updateDayTaskByDayAndTaskInternal(
 		'day' | 'task'
 	>
 ): Promise<number> {
-	const dayTaskOS = transaction.objectStore(ObjectStoreName.DAY_TASK);
-
 	const retrievedDayTask = await getDayTaskForDayAndTaskInternal(transaction, dayTask);
 
 	if (!retrievedDayTask) {

--- a/app/assets/js/src/database/internal/updateTaskInternal.ts
+++ b/app/assets/js/src/database/internal/updateTaskInternal.ts
@@ -36,12 +36,14 @@ export async function updateTaskInternal(
 			}
 		}
 
+		const updatedTask = {
+			...taskCursorValue,
+			...task,
+		};
+
 		requests.push(
 			getIdbRequestPromise(
-				taskCursor.update({
-					...taskCursorValue,
-					...task,
-				})
+				taskCursor.update(updatedTask)
 			)
 		);
 	}

--- a/app/assets/js/src/types/Command.ts
+++ b/app/assets/js/src/types/Command.ts
@@ -1,4 +1,5 @@
 import type { EnumTypeOf } from 'utils';
+import type { SaveAction } from './SaveAction';
 
 export const Command = {
 	DAY_ADD_NEW: 'day-add-new',
@@ -18,7 +19,7 @@ declare module 'registers/commands' {
 		[Command.DAY_ADD_NEW]: [dayName: string];
 		[Command.TASK_ADD_NEW]: [dayName: string];
 		[Command.TASK_GO_TO_EXISTING]: [taskId: number];
-		[Command.DATA_SAVE]: [];
+		[Command.DATA_SAVE]: [saveActions: readonly SaveAction[]];
 		[Command.DATA_EXPORT]: [];
 		[Command.DATA_IMPORT]: [];
 		[Command.THEME_TOGGLE]: [];

--- a/app/assets/js/src/types/SaveAction.ts
+++ b/app/assets/js/src/types/SaveAction.ts
@@ -1,0 +1,20 @@
+import type { EnumTypeOf, ExpandType } from 'utils';
+
+export const SaveType = {
+	TASK_NOTE: 'task note',
+} as const;
+export type SaveType = EnumTypeOf<typeof SaveType>;
+
+interface SaveActionByType {
+	[SaveType.TASK_NOTE]: {
+		task: number;
+		note: string;
+	};
+}
+
+/**
+ * This immediately indexed mapped type creates a discriminated union type of all potential save actions, discriminated by {@linkcode SaveType}.
+ */
+export type SaveAction = {
+	[T in SaveType]: ExpandType<{ type: T; } & SaveActionByType[T]>;
+}[SaveType];


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Since the database migration for version 2, saving all data to IndexedDB is noticeably slow.

<!-- Describe your solution -->
This PR updates the process for updating a task's note so that, instead of re-saving _everything_ to IndexedDB, only that task's note is updated.

It adds a helper class, `SaveHelper`, for this purpose. The intent is to extend this class to process more types of `SaveAction` object later on, until each individual piece of data can be saved on its own.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
