### PR TITLE
Save day task note

### DIFF
--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.test.tsx
@@ -1,0 +1,104 @@
+import { h } from 'preact';
+
+import {
+	beforeAll,
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+
+import { Command } from 'types/Command';
+import { addCommandListener, registerCommand } from 'registers/commands';
+
+import { clear } from 'data';
+
+import { SaveType } from 'types/SaveAction';
+
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
+
+import { DayTaskNote } from './DayTaskNote';
+import { afterEach, beforeEach } from 'node:test';
+
+describe('DayTaskNote', () => {
+	beforeAll(() => {
+		registerCommand(Command.DATA_SAVE, { name: 'Save data' });
+	});
+
+	beforeEach(() => {
+		clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders the day task\'s note', () => {
+		const { getByText } = render(<OrangeTwistContext.Provider
+			value={{
+				isLoading: false,
+			}}
+		>
+			<DayTaskNote
+				dayTask={{
+					dayName: '2026-08-04',
+					taskId: 1,
+					summary: 'Summary',
+					note: 'Day task note',
+					status: 'todo',
+				}}
+			/>
+		</OrangeTwistContext.Provider>);
+
+		expect(getByText('Day task note')).toBeInTheDocument();
+	});
+
+	test('saves note after change', async () => {
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		const user = userEvent.setup();
+
+		const spy = jest.fn();
+
+		addCommandListener(Command.DATA_SAVE, spy, { signal });
+
+		const { getAllByRole } = render(<OrangeTwistContext.Provider
+			value={{
+				isLoading: false,
+			}}
+		>
+			<DayTaskNote
+				dayTask={{
+					dayName: '2026-08-04',
+					taskId: 1,
+					summary: 'Summary',
+					note: 'Day task note',
+					status: 'todo',
+				}}
+			/>
+		</OrangeTwistContext.Provider>);
+
+		const noteEditButton = getAllByRole('button', { name: 'Edit note' })[0];
+		await user.click(noteEditButton);
+		await user.keyboard(' edited');
+
+		expect(spy).not.toHaveBeenCalled();
+
+		await user.click(document.body);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith([{
+			type: SaveType.DAY_TASK_NOTE_LEGACY,
+			dayName: '2026-08-04',
+			taskId: 1,
+			note: 'Day task note edited',
+		}]);
+
+		controller.abort();
+	});
+});

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.test.tsx
@@ -1,7 +1,9 @@
 import { h } from 'preact';
 
 import {
+	afterEach,
 	beforeAll,
+	beforeEach,
 	describe,
 	expect,
 	jest,
@@ -22,7 +24,6 @@ import { SaveType } from 'types/SaveAction';
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import { DayTaskNote } from './DayTaskNote';
-import { afterEach, beforeEach } from 'node:test';
 
 describe('DayTaskNote', () => {
 	beforeAll(() => {

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -15,6 +15,7 @@ import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import type { MarkdownApi } from 'components/shared/Markdown';
 import { Note } from 'components/shared';
+import { SaveType } from 'types/SaveAction';
 
 interface DayTaskNoteProps {
 	dayTask: Readonly<DayTaskInfo>;
@@ -25,12 +26,29 @@ export function DayTaskNote(props: DayTaskNoteProps): JSX.Element {
 	const { dayName, taskId } = dayTask;
 
 	const { isLoading } = useContext(OrangeTwistContext);
+	/** Keep a reference to the note for immediate saving before re-renredering. */
+	const noteRef = useRef(dayTask.note);
+	// Make sure to update the ref if the day task note changes from other sources
+	useEffect(() => {
+		noteRef.current = dayTask.note;
+	}, [dayTask.note]);
 
-	const setDayTaskNote = useCallback((note: string) => {
-		setDayTaskInfo({ dayName, taskId }, { note });
+	const setDayTaskNote = useCallback(
+		(note: string) => {
+			noteRef.current = note;
+			setDayTaskInfo({ dayName, taskId }, { note });
+		},
+		[dayName, taskId]
+	);
+
+	const saveChanges = useCallback(() => {
+		fireCommand(Command.DATA_SAVE, [{
+			type: SaveType.DAY_TASK_NOTE_LEGACY,
+			dayName,
+			taskId,
+			note: noteRef.current,
+		}]);
 	}, [dayName, taskId]);
-
-	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
 
 	const markdownApiRef = useRef<MarkdownApi | null>(null);
 	// When data is finished loading re-render Markdown

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
@@ -44,13 +44,14 @@ describe('TaskNote', () => {
 				isLoading: false,
 			}}
 		>
-			<TaskNote task={{
-				id: 1,
-				name: 'Test task',
-				note: 'Task note',
-				status: 'todo',
-				sortIndex: 1,
-			}}
+			<TaskNote
+				task={{
+					id: 1,
+					name: 'Test task',
+					note: 'Task note',
+					status: 'todo',
+					sortIndex: 1,
+				}}
 			/>
 		</OrangeTwistContext.Provider>);
 
@@ -72,13 +73,14 @@ describe('TaskNote', () => {
 				isLoading: false,
 			}}
 		>
-			<TaskNote task={{
-				id: 1,
-				name: 'Test task',
-				note: 'Task note',
-				status: 'todo',
-				sortIndex: 1,
-			}}
+			<TaskNote
+				task={{
+					id: 1,
+					name: 'Test task',
+					note: 'Task note',
+					status: 'todo',
+					sortIndex: 1,
+				}}
 			/>
 		</OrangeTwistContext.Provider>);
 

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
@@ -10,7 +10,10 @@ import { SaveType } from 'types/SaveAction';
 import { createTestData } from '../test-utils';
 import { getDatabase } from '../utils';
 import { ObjectStoreName } from '../metadata';
-import { getTaskInternal } from '../internal';
+import {
+	getDayTaskForDayAndTaskInternal,
+	getTaskInternal,
+} from '../internal';
 
 import { SaveHelper } from './SaveHelper';
 
@@ -55,5 +58,73 @@ describe('SaveHelper', () => {
 
 		expect(afterTask1?.note).toBe('New note 1');
 		expect(afterTask2?.note).toBe('New note 2');
+	});
+
+	test('saves day task notes via legacy interface', async () => {
+		let readTransaction = db.transaction([
+			ObjectStoreName.DAY_TASK,
+		], 'readonly');
+		const beforeDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
+		const beforeDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+
+		expect(beforeDayTask1?.note).toBe('Note for task 1 day 1');
+		expect(beforeDayTask2?.note).toBe('Note for task 2 day 1');
+
+		await saveHelper.save([
+			{
+				type: SaveType.DAY_TASK_NOTE_LEGACY,
+				dayName: '2026-04-26',
+				taskId: 1,
+				note: 'New note 1',
+			},
+			{
+				type: SaveType.DAY_TASK_NOTE_LEGACY,
+				dayName: '2026-04-26',
+				taskId: 2,
+				note: 'New note 2',
+			},
+		]);
+
+		readTransaction = db.transaction([
+			ObjectStoreName.DAY_TASK,
+		], 'readonly');
+		const afterDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
+		const afterDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+
+		expect(afterDayTask1?.note).toBe('New note 1');
+		expect(afterDayTask2?.note).toBe('New note 2');
+	});
+
+	test('saves day task notes', async () => {
+		let readTransaction = db.transaction([
+			ObjectStoreName.DAY_TASK,
+		], 'readonly');
+		const beforeDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
+		const beforeDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+
+		expect(beforeDayTask1?.note).toBe('Note for task 1 day 1');
+		expect(beforeDayTask2?.note).toBe('Note for task 2 day 1');
+
+		await saveHelper.save([
+			{
+				type: SaveType.DAY_TASK_NOTE,
+				dayTask: 1,
+				note: 'New note 1',
+			},
+			{
+				type: SaveType.DAY_TASK_NOTE,
+				dayTask: 2,
+				note: 'New note 2',
+			},
+		]);
+
+		readTransaction = db.transaction([
+			ObjectStoreName.DAY_TASK,
+		], 'readonly');
+		const afterDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
+		const afterDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+
+		expect(afterDayTask1?.note).toBe('New note 1');
+		expect(afterDayTask2?.note).toBe('New note 2');
 	});
 });

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.test.ts
@@ -12,6 +12,7 @@ import { getDatabase } from '../utils';
 import { ObjectStoreName } from '../metadata';
 import {
 	getDayTaskForDayAndTaskInternal,
+	getDayTaskInternal,
 	getTaskInternal,
 } from '../internal';
 
@@ -99,8 +100,8 @@ describe('SaveHelper', () => {
 		let readTransaction = db.transaction([
 			ObjectStoreName.DAY_TASK,
 		], 'readonly');
-		const beforeDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
-		const beforeDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+		const beforeDayTask1 = await getDayTaskInternal(readTransaction, 1);
+		const beforeDayTask2 = await getDayTaskInternal(readTransaction, 2);
 
 		expect(beforeDayTask1?.note).toBe('Note for task 1 day 1');
 		expect(beforeDayTask2?.note).toBe('Note for task 2 day 1');
@@ -121,8 +122,8 @@ describe('SaveHelper', () => {
 		readTransaction = db.transaction([
 			ObjectStoreName.DAY_TASK,
 		], 'readonly');
-		const afterDayTask1 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 1 });
-		const afterDayTask2 = await getDayTaskForDayAndTaskInternal(readTransaction, { day: 1, task: 2 });
+		const afterDayTask1 = await getDayTaskInternal(readTransaction, 1);
+		const afterDayTask2 = await getDayTaskInternal(readTransaction, 2);
 
 		expect(afterDayTask1?.note).toBe('New note 1');
 		expect(afterDayTask2?.note).toBe('New note 2');

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.ts
@@ -8,7 +8,7 @@ import {
 	getDayTaskForDayAndTaskInternal,
 	updateDayTaskInternal,
 	updateTaskInternal,
-} from 'database/internal';
+} from '../internal';
 
 /**
  * A helper class for managing database save actions.
@@ -72,7 +72,7 @@ export class SaveHelper {
 	}
 
 	/**
-	 * Save the note of a single day task, referenced by its legacy key instead of its ID.
+	 * Save the note of a single day task, referenced by its day name and task ID instead of its ID.
 	 */
 	async #saveDayTaskNoteLegacy(
 		action: Extract<

--- a/app/assets/js/src/database/SaveHelper/SaveHelper.ts
+++ b/app/assets/js/src/database/SaveHelper/SaveHelper.ts
@@ -2,8 +2,13 @@ import { SaveType, type SaveAction } from 'types/SaveAction';
 import { assertAllUnionMembersHandled } from 'utils';
 
 import { ObjectStoreName } from '../metadata';
-import { getDatabase } from '../utils';
-import { updateTaskInternal } from 'database/internal';
+import { getDatabase, getDayNameParts } from '../utils';
+import {
+	getDayByDateInternal,
+	getDayTaskForDayAndTaskInternal,
+	updateDayTaskInternal,
+	updateTaskInternal,
+} from 'database/internal';
 
 /**
  * A helper class for managing database save actions.
@@ -26,8 +31,12 @@ export class SaveHelper {
 		for (const action of actions) {
 			if (action.type === SaveType.TASK_NOTE) {
 				this.#saveTaskNote(action, transaction);
+			} else if (action.type === SaveType.DAY_TASK_NOTE_LEGACY) {
+				this.#saveDayTaskNoteLegacy(action, transaction);
+			} else if (action.type === SaveType.DAY_TASK_NOTE) {
+				this.#saveDayTaskNote(action, transaction);
 			} else {
-				assertAllUnionMembersHandled(action.type);
+				assertAllUnionMembersHandled(action);
 			}
 		}
 	}
@@ -48,6 +57,53 @@ export class SaveHelper {
 	}
 
 	/**
+	 * Save the note of a single day task.
+	 */
+	async #saveDayTaskNote(
+		action: Extract<
+			SaveAction, { type: typeof SaveType.DAY_TASK_NOTE; }
+		>,
+		transaction: IDBTransaction,
+	): Promise<void> {
+		await updateDayTaskInternal(transaction, {
+			id: action.dayTask,
+			note: action.note,
+		});
+	}
+
+	/**
+	 * Save the note of a single day task, referenced by its legacy key instead of its ID.
+	 */
+	async #saveDayTaskNoteLegacy(
+		action: Extract<
+			SaveAction, { type: typeof SaveType.DAY_TASK_NOTE_LEGACY; }
+		>,
+		transaction: IDBTransaction
+	): Promise<void> {
+		const { dayName, taskId } = action;
+
+		const [year, month, day] = getDayNameParts(dayName);
+
+		const dayInfo = await getDayByDateInternal(transaction, { year, month, day });
+		if (!dayInfo) {
+			throw new Error(`Could not save day task - unable to find associated day ${JSON.stringify({ year, month, day })}`);
+		}
+		const dayTask = await getDayTaskForDayAndTaskInternal(transaction, {
+			day: dayInfo.id,
+			task: taskId,
+		});
+		if (!dayTask) {
+			throw new Error(`Could not save day task - unable to find day task for day ${JSON.stringify({ year, month, day })} and task ${taskId}`);
+		}
+
+		this.#saveDayTaskNote({
+			type: SaveType.DAY_TASK_NOTE,
+			dayTask: dayTask.id,
+			note: action.note,
+		}, transaction);
+	}
+
+	/**
 	 * For a given set of {@linkcode SaveAction}s, gather the required object stores needed to process them all.
 	 */
 	#gatherTransactionRequirements(
@@ -59,8 +115,15 @@ export class SaveHelper {
 			if (action.type === SaveType.TASK_NOTE) {
 				objectStores.add(ObjectStoreName.TASK);
 				objectStores.add(ObjectStoreName.STATUS);
+			} else if (action.type === SaveType.DAY_TASK_NOTE) {
+				objectStores.add(ObjectStoreName.DAY_TASK);
+				objectStores.add(ObjectStoreName.STATUS);
+			} else if (action.type === SaveType.DAY_TASK_NOTE_LEGACY) {
+				objectStores.add(ObjectStoreName.DAY_TASK);
+				objectStores.add(ObjectStoreName.STATUS);
+				objectStores.add(ObjectStoreName.DAY);
 			} else {
-				assertAllUnionMembersHandled(action.type);
+				assertAllUnionMembersHandled(action);
 			}
 		}
 

--- a/app/assets/js/src/database/internal/getDayTaskForDayAndTaskInternal.test.ts
+++ b/app/assets/js/src/database/internal/getDayTaskForDayAndTaskInternal.test.ts
@@ -37,7 +37,7 @@ describe('getDayTaskForDayAndTaskInternal', () => {
 		} satisfies Awaited<ReturnType<typeof getDayTaskForDayAndTaskInternal>>);
 	});
 
-	test('returns null if no such day exists', async () => {
+	test('returns null if no such day task exists', async () => {
 		const db = await getDatabase();
 		const transaction = db.transaction(ObjectStoreName.DAY_TASK);
 

--- a/app/assets/js/src/database/internal/getDayTaskInternal.test.ts
+++ b/app/assets/js/src/database/internal/getDayTaskInternal.test.ts
@@ -1,0 +1,42 @@
+import {
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from '@jest/globals';
+
+import { createTestData } from '../test-utils';
+import { getDatabase } from '../utils';
+import { ObjectStoreName } from '../metadata';
+
+import { getDayTaskInternal } from './getDayTaskInternal';
+
+describe('getDayTaskInternal', () => {
+	beforeAll(() => createTestData());
+
+	test('receives a day task by its day and task', async () => {
+		const db = await getDatabase();
+		const transaction = db.transaction(ObjectStoreName.DAY_TASK);
+
+		const dayTask = await getDayTaskInternal(transaction, 2);
+
+		expect(dayTask).toEqual({
+			id: 2,
+			day: 1,
+			task: 2,
+			note: 'Note for task 2 day 1',
+			summary: 'Summary for task 2 day 1',
+			status: 2,
+			sortIndex: 0,
+		} satisfies Awaited<ReturnType<typeof getDayTaskInternal>>);
+	});
+
+	test('returns null if no such day exists', async () => {
+		const db = await getDatabase();
+		const transaction = db.transaction(ObjectStoreName.DAY_TASK);
+
+		const dayTask = await getDayTaskInternal(transaction, -1);
+
+		expect(dayTask).toBeNull();
+	});
+});

--- a/app/assets/js/src/database/internal/getDayTaskInternal.test.ts
+++ b/app/assets/js/src/database/internal/getDayTaskInternal.test.ts
@@ -14,7 +14,7 @@ import { getDayTaskInternal } from './getDayTaskInternal';
 describe('getDayTaskInternal', () => {
 	beforeAll(() => createTestData());
 
-	test('receives a day task by its day and task', async () => {
+	test('receives a day task by its ID', async () => {
 		const db = await getDatabase();
 		const transaction = db.transaction(ObjectStoreName.DAY_TASK);
 
@@ -31,7 +31,7 @@ describe('getDayTaskInternal', () => {
 		} satisfies Awaited<ReturnType<typeof getDayTaskInternal>>);
 	});
 
-	test('returns null if no such day exists', async () => {
+	test('returns null if no such day task exists', async () => {
 		const db = await getDatabase();
 		const transaction = db.transaction(ObjectStoreName.DAY_TASK);
 

--- a/app/assets/js/src/database/internal/getDayTaskInternal.ts
+++ b/app/assets/js/src/database/internal/getDayTaskInternal.ts
@@ -7,7 +7,7 @@ import type { DatabaseData } from '../types';
  * Takes an existing {@linkcode IDBTransaction} and adds a request to get a day task by its ID.
  *
  * @param transaction An {@linkcode IDBTransaction} with read permission and access to the {@linkcode ObjectStoreName.DAY_TASK} object store.
- * @param dayTask An object specifying the day and task for the day task to retrieve.
+ * @param dayTaskId The ID of the the day task to retrieve.
  *
  * @returns A {@linkcode Promise} that resolves with the retrieved day task, or `null` if no such day task exists.
  */

--- a/app/assets/js/src/database/internal/getDayTaskInternal.ts
+++ b/app/assets/js/src/database/internal/getDayTaskInternal.ts
@@ -1,0 +1,32 @@
+import { getIdbRequestPromise } from 'utils';
+
+import { ObjectStoreName } from '../metadata';
+import type { DatabaseData } from '../types';
+
+/**
+ * Takes an existing {@linkcode IDBTransaction} and adds a request to get a day task by its ID.
+ *
+ * @param transaction An {@linkcode IDBTransaction} with read permission and access to the {@linkcode ObjectStoreName.DAY_TASK} object store.
+ * @param dayTask An object specifying the day and task for the day task to retrieve.
+ *
+ * @returns A {@linkcode Promise} that resolves with the retrieved day task, or `null` if no such day task exists.
+ */
+export async function getDayTaskInternal(
+	transaction: IDBTransaction,
+	dayTaskId: number
+): Promise<
+	| DatabaseData[typeof ObjectStoreName.DAY_TASK][number]
+	| null
+> {
+	const dayTaskOS = transaction.objectStore(ObjectStoreName.DAY_TASK);
+
+	// This type assertion is safe because of other controls around what can be inserted into the database
+	const request = dayTaskOS.get(dayTaskId) as IDBRequest<
+		| DatabaseData[typeof ObjectStoreName.DAY_TASK][number]
+		| undefined
+	>;
+
+	const result = await getIdbRequestPromise(request);
+
+	return result ?? null;
+}

--- a/app/assets/js/src/database/internal/index.ts
+++ b/app/assets/js/src/database/internal/index.ts
@@ -11,6 +11,7 @@ export { removeTaskInternal } from './removeTaskInternal';
 export { updateTaskInternal } from './updateTaskInternal';
 export { getTasksInternal } from './getTasksInternal';
 
+export { getDayTaskInternal } from './getDayTaskInternal';
 export { getDayTaskForDayAndTaskInternal } from './getDayTaskForDayAndTaskInternal';
 export { addDayTaskInternal } from './addDayTaskInternal';
 export { removeDayTaskInternal } from './removeDayTaskInternal';

--- a/app/assets/js/src/database/internal/updateDayTaskInternal.test.ts
+++ b/app/assets/js/src/database/internal/updateDayTaskInternal.test.ts
@@ -9,7 +9,7 @@ import { ObjectStoreName } from '../metadata';
 import { createTestData } from '../test-utils';
 import { getDatabase } from '../utils';
 
-import { getDayTaskForDayAndTaskInternal } from './getDayTaskForDayAndTaskInternal';
+import { getDayTaskInternal } from './getDayTaskInternal';
 
 import { updateDayTaskInternal } from './updateDayTaskInternal';
 
@@ -36,10 +36,7 @@ describe('updateDayTaskInternal', () => {
 
 		expect(result).toBe(1);
 
-		const updatedDayTask = await getDayTaskForDayAndTaskInternal(transaction, {
-			day: 1,
-			task: 1,
-		});
+		const updatedDayTask = await getDayTaskInternal(transaction, 1);
 
 		expect(updatedDayTask).toEqual({
 			id: 1,
@@ -49,7 +46,7 @@ describe('updateDayTaskInternal', () => {
 			summary: 'Updated summary',
 			status: 3,
 			sortIndex: 1,
-		} satisfies Awaited<ReturnType<typeof getDayTaskForDayAndTaskInternal>>);
+		} satisfies Awaited<ReturnType<typeof getDayTaskInternal>>);
 	});
 
 	test('throws an error if the day task doesn\'t exist', async () => {

--- a/app/assets/js/src/database/utils/getDayNameParts.ts
+++ b/app/assets/js/src/database/utils/getDayNameParts.ts
@@ -1,7 +1,7 @@
 /**
  * Convert a legacy day name into numeric parts. For example, `'2026-04-12'` becomes `[2026, 4, 12]`.
  */
-export function getDayNameParts(dayName: string): [number, number, number] {
+export function getDayNameParts(dayName: string): [year: number, month: number, day: number] {
 	const parts = dayName.split('-');
 	const year = Number(parts[0]);
 	const month = Number(parts[1]);

--- a/app/assets/js/src/types/SaveAction.ts
+++ b/app/assets/js/src/types/SaveAction.ts
@@ -2,12 +2,25 @@ import type { EnumTypeOf, ExpandType } from 'utils';
 
 export const SaveType = {
 	TASK_NOTE: 'task note',
+
+	// TODO: Remove this once day task notes can be saved via the day task's ID
+	DAY_TASK_NOTE_LEGACY: 'day task note (legacy)',
+	DAY_TASK_NOTE: 'day task note',
 } as const;
 export type SaveType = EnumTypeOf<typeof SaveType>;
 
 interface SaveActionByType {
 	[SaveType.TASK_NOTE]: {
 		task: number;
+		note: string;
+	};
+	[SaveType.DAY_TASK_NOTE_LEGACY]: {
+		dayName: string;
+		taskId: number;
+		note: string;
+	};
+	[SaveType.DAY_TASK_NOTE]: {
+		dayTask: number;
 		note: string;
 	};
 }


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Since the database migration for version 2, saving all data to IndexedDB is noticeably slow.

<!-- Describe your solution -->
This PR updates the process for updating a day task's note so that, instead of re-saving _everything_ to IndexedDB, only that day task's note is updated.

Because `DayTaskNote` doesn't currently know the ID of the day task whose note it's displaying, this save action currently works by an intermediate step that looks up the day task. A `TODO` comment is added to remove this legacy step once `DayTaskNote` knows the ID of the day task whose note it's displaying.

I've also added a test suite for `DayTaskNote`, and a `getDayTaskInternal` database function.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
