### PR TITLE
Save day note

### DIFF
--- a/app/assets/js/src/components/days/DayNote.test.tsx
+++ b/app/assets/js/src/components/days/DayNote.test.tsx
@@ -1,0 +1,100 @@
+import { h } from 'preact';
+
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
+
+import { cleanup, render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+
+import { Command } from 'types/Command';
+import { addCommandListener, registerCommand } from 'registers/commands';
+
+import { clear } from 'data';
+
+import { SaveType } from 'database';
+
+import { OrangeTwistContext } from 'components/OrangeTwistContext';
+
+import { DayNote } from './DayNote';
+
+describe('DayNote', () => {
+	beforeAll(() => {
+		registerCommand(Command.DATA_SAVE, { name: 'Save data' });
+	});
+
+	beforeEach(() => {
+		clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders the day\'s note', () => {
+		const { getByText } = render(<OrangeTwistContext.Provider
+			value={{
+				isLoading: false,
+			}}
+		>
+			<DayNote
+				day={{
+					name: '2026-08-04',
+					note: 'Day note',
+					tasks: [],
+				}}
+			/>
+		</OrangeTwistContext.Provider>);
+
+		expect(getByText('Day note')).toBeInTheDocument();
+	});
+
+	test('saves note after change', async () => {
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		const user = userEvent.setup();
+
+		const spy = jest.fn();
+
+		addCommandListener(Command.DATA_SAVE, spy, { signal });
+
+		const { getByRole } = render(<OrangeTwistContext.Provider
+			value={{
+				isLoading: false,
+			}}
+		>
+			<DayNote
+				day={{
+					name: '2026-08-04',
+					note: 'Day note',
+					tasks: [],
+				}}
+			/>
+		</OrangeTwistContext.Provider>);
+
+		const noteEditButton = getByRole('button', { name: 'Edit note' });
+		await user.click(noteEditButton);
+		await user.keyboard(' edited');
+
+		expect(spy).not.toHaveBeenCalled();
+
+		await user.click(document.body);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith([{
+			type: SaveType.DAY_LEGACY,
+			dayName: '2026-08-04',
+			day: { note: 'Day note edited' },
+		}]);
+
+		controller.abort();
+	});
+});

--- a/app/assets/js/src/components/days/DayNote.tsx
+++ b/app/assets/js/src/components/days/DayNote.tsx
@@ -13,6 +13,7 @@ import {
 	setDayInfo,
 	type DayInfo,
 } from 'data';
+import { SaveType } from 'database';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
@@ -32,13 +33,28 @@ export function DayNote(props: DayNoteProps): JSX.Element {
 	const { name } = day;
 
 	const { isLoading } = useContext(OrangeTwistContext);
+	/** Keep a reference to the note for immediate saving before re-renredering. */
+	const noteRef = useRef(day.note);
+	// Make sure to update the ref if the task note changes from other sources
+	useEffect(() => {
+		noteRef.current = day.note;
+	}, [day.note]);
 
 	const onNoteChange = useCallback(
-		(note: string) => setDayInfo(name, { note }),
+		(note: string) => {
+			noteRef.current = note;
+			setDayInfo(name, { note });
+		},
 		[name]
 	);
 
-	const saveChanges = useCallback(() => fireCommand(Command.DATA_SAVE), []);
+	const saveChanges = useCallback(() => {
+		fireCommand(Command.DATA_SAVE, [{
+			type: SaveType.DAY_LEGACY,
+			dayName: day.name,
+			day: { note: noteRef.current },
+		}]);
+	}, [day.name]);
 
 	const markdownApiRef = useRef<MarkdownApi | null>(null);
 	// When data is finished loading re-render Markdown

--- a/app/assets/js/src/database/access/SaveAction.ts
+++ b/app/assets/js/src/database/access/SaveAction.ts
@@ -9,6 +9,10 @@ export const SaveType = {
 	// TODO: Remove this once day tasks can be saved via the day task's ID
 	DAY_TASK_LEGACY: 'day task (legacy)',
 	DAY_TASK: 'day task',
+
+	// TODO: Remove this once days can be saved via the day's ID
+	DAY_LEGACY: 'day (legacy)',
+	DAY: 'day',
 } as const;
 export type SaveType = EnumTypeOf<typeof SaveType>;
 
@@ -38,6 +42,24 @@ interface SaveActionByType {
 			Omit<
 				DatabaseData[typeof ObjectStoreName.DAY_TASK][number],
 				'id' | 'day' | 'task'
+			>
+		>>;
+	};
+	[SaveType.DAY]: {
+		id: number;
+		day: ExpandType<Partial<
+			Omit<
+				DatabaseData[typeof ObjectStoreName.DAY][number],
+				'id' | 'year' | 'month' | 'day'
+			>
+		>>;
+	};
+	[SaveType.DAY_LEGACY]: {
+		dayName: string;
+		day: ExpandType<Partial<
+			Omit<
+				DatabaseData[typeof ObjectStoreName.DAY][number],
+				'id' | 'year' | 'month' | 'day'
 			>
 		>>;
 	};

--- a/app/assets/js/src/database/access/save.test.ts
+++ b/app/assets/js/src/database/access/save.test.ts
@@ -9,6 +9,8 @@ import { createTestData } from '../test-utils';
 import { getDatabase } from '../utils';
 import { ObjectStoreName } from '../metadata';
 import {
+	getDayByDateInternal,
+	getDayInternal,
 	getDayTaskForDayAndTaskInternal,
 	getDayTaskInternal,
 	getTaskInternal,
@@ -178,7 +180,7 @@ describe('SaveHelper', () => {
 		});
 	});
 
-	test('saves day task notes', async () => {
+	test('saves day tasks', async () => {
 		let readTransaction = db.transaction([
 			ObjectStoreName.DAY_TASK,
 		], 'readonly');
@@ -238,6 +240,140 @@ describe('SaveHelper', () => {
 			sortIndex: 3,
 			status: 3,
 			summary: 'Test day task 2 updated',
+		});
+	});
+
+	test('saves days via legacy interface', async () => {
+		let readTransaction = db.transaction([
+			ObjectStoreName.DAY,
+		], 'readonly');
+		const beforeDay1 = await getDayByDateInternal(readTransaction, { year: 2026, month: 4, day: 26 });
+		const beforeDay2 = await getDayByDateInternal(readTransaction, { year: 2026, month: 4, day: 27 });
+
+		expect(beforeDay1).toEqual({
+			id: 1,
+			year: 2026,
+			month: 4,
+			day: 26,
+			note: 'Test note 1',
+		});
+		expect(beforeDay2).toEqual({
+			id: 2,
+			year: 2026,
+			month: 4,
+			day: 27,
+			note: 'Test note 2',
+		});
+
+		await save([
+			{
+				type: SaveType.DAY_LEGACY,
+				dayName: '2026-04-26',
+				// Ensure undefined and extraneous properties are ignored
+				day: {
+					note: 'New note 1',
+					// @ts-expect-error Ignore for test
+					extra: 'test',
+				},
+			},
+			{
+				type: SaveType.DAY_LEGACY,
+				dayName: '2026-04-27',
+				// Ensure all properties get updated
+				day: {
+					note: 'New note 2',
+				} satisfies Required<
+					Extract<SaveAction, { type: typeof SaveType.DAY_LEGACY; }>['day']
+				>,
+			},
+		]);
+
+		readTransaction = db.transaction([
+			ObjectStoreName.DAY,
+		], 'readonly');
+		const afterDay1 = await getDayByDateInternal(readTransaction, { year: 2026, month: 4, day: 26 });
+		const afterDay2 = await getDayByDateInternal(readTransaction, { year: 2026, month: 4, day: 27 });
+
+		expect(afterDay1).toEqual({
+			id: 1,
+			year: 2026,
+			month: 4,
+			day: 26,
+			note: 'New note 1',
+		});
+		expect(afterDay2).toEqual({
+			id: 2,
+			year: 2026,
+			month: 4,
+			day: 27,
+			note: 'New note 2',
+		});
+	});
+
+	test('saves days', async () => {
+		let readTransaction = db.transaction([
+			ObjectStoreName.DAY,
+		], 'readonly');
+		const beforeDay1 = await getDayInternal(readTransaction, 1);
+		const beforeDay2 = await getDayInternal(readTransaction, 2);
+
+		expect(beforeDay1).toEqual({
+			id: 1,
+			year: 2026,
+			month: 4,
+			day: 26,
+			note: 'Test note 1',
+		});
+		expect(beforeDay2).toEqual({
+			id: 2,
+			year: 2026,
+			month: 4,
+			day: 27,
+			note: 'Test note 2',
+		});
+
+		await save([
+			{
+				type: SaveType.DAY,
+				id: 1,
+				// Ensure undefined and extraneous properties are ignored
+				day: {
+					note: undefined,
+					// @ts-expect-error Ignore for test
+					extra: 'test',
+				},
+			},
+			{
+				type: SaveType.DAY,
+				id: 2,
+				// Ensure all properties get updated
+				day: {
+					note: 'New note 2',
+				} satisfies Required<
+					Extract<SaveAction, { type: typeof SaveType.DAY_LEGACY; }>['day']
+				>,
+			},
+		]);
+
+		readTransaction = db.transaction([
+			ObjectStoreName.DAY,
+		], 'readonly');
+		const afterDay1 = await getDayInternal(readTransaction, 1);
+		const afterDay2 = await getDayInternal(readTransaction, 2);
+
+		expect(afterDay1).toEqual({
+			id: 1,
+			year: 2026,
+			month: 4,
+			day: 26,
+			note: 'Test note 1',
+		});
+		expect(afterDay2).toEqual({
+			id: 2,
+			year: 2026,
+			month: 4,
+			day: 27,
+			note: 'New note 2',
 		});
 	});
 });

--- a/app/assets/js/src/database/access/save.ts
+++ b/app/assets/js/src/database/access/save.ts
@@ -5,6 +5,7 @@ import { getDayNameParts } from '../utils';
 import {
 	getDayByDateInternal,
 	getDayTaskForDayAndTaskInternal,
+	updateDayInternal,
 	updateDayTaskInternal,
 	updateTaskInternal,
 } from '../internal';
@@ -27,9 +28,13 @@ export async function save(actions: readonly SaveAction[]): Promise<void> {
 		if (action.type === SaveType.TASK) {
 			saveTask(action, transaction);
 		} else if (action.type === SaveType.DAY_TASK_LEGACY) {
-			saveDayTaskNoteLegacy(action, transaction);
+			saveDayTaskLegacy(action, transaction);
 		} else if (action.type === SaveType.DAY_TASK) {
 			saveDayTask(action, transaction);
+		} else if (action.type === SaveType.DAY) {
+			saveDay(action, transaction);
+		} else if (action.type === SaveType.DAY_LEGACY) {
+			saveDayLegacy(action, transaction);
 		} else {
 			assertAllUnionMembersHandled(action);
 		}
@@ -97,7 +102,7 @@ async function saveDayTask(
 /**
  * Save the note of a single day task, referenced by its day name and task ID instead of its ID.
  */
-async function saveDayTaskNoteLegacy(
+async function saveDayTaskLegacy(
 	action: Extract<
 		SaveAction, { type: typeof SaveType.DAY_TASK_LEGACY; }
 	>,
@@ -127,6 +132,51 @@ async function saveDayTaskNoteLegacy(
 }
 
 /**
+ * Save a single day.
+ */
+async function saveDay(
+	action: Extract<
+		SaveAction, { type: typeof SaveType.DAY; }
+	>,
+	transaction: IDBTransaction,
+): Promise<void> {
+	// Protect against extraneous and undefined properties
+	const dayToSave: Parameters<typeof updateDayInternal>[1] = {
+		id: action.id,
+	};
+	if (typeof action.day.note !== 'undefined') {
+		dayToSave.note = action.day.note;
+	}
+
+	await updateDayInternal(transaction, dayToSave);
+}
+
+/**
+ * Save the note of a single day, referenced by its day name instead of its ID.
+ */
+async function saveDayLegacy(
+	action: Extract<
+		SaveAction, { type: typeof SaveType.DAY_LEGACY; }
+	>,
+	transaction: IDBTransaction
+): Promise<void> {
+	const { dayName } = action;
+
+	const [year, month, day] = getDayNameParts(dayName);
+
+	const dayInfo = await getDayByDateInternal(transaction, { year, month, day });
+	if (!dayInfo) {
+		throw new Error(`Could not save day task - unable to find associated day ${JSON.stringify({ year, month, day })}`);
+	}
+
+	saveDay({
+		type: SaveType.DAY,
+		id: dayInfo.id,
+		day: action.day,
+	}, transaction);
+}
+
+/**
  * For a given set of {@linkcode SaveAction}s, gather the required object stores needed to process them all.
  */
 function gatherTransactionRequirements(
@@ -144,6 +194,11 @@ function gatherTransactionRequirements(
 		} else if (action.type === SaveType.DAY_TASK_LEGACY) {
 			objectStores.add(ObjectStoreName.DAY_TASK);
 			objectStores.add(ObjectStoreName.STATUS);
+			objectStores.add(ObjectStoreName.DAY);
+		} else if (
+			action.type === SaveType.DAY ||
+			action.type === SaveType.DAY_LEGACY
+		) {
 			objectStores.add(ObjectStoreName.DAY);
 		} else {
 			assertAllUnionMembersHandled(action);


### PR DESCRIPTION
<!-- Describe the problem being solved -->
Since the database migration for version 2, saving all data to IndexedDB is noticeably slow.

<!-- Describe your solution -->
This PR updates the process for updating a day's note so that, instead of re-saving _everything_ to IndexedDB, only that day task's note is updated.

Because `DayNote` doesn't currently know the ID of the day whose note it's displaying, this save action currently works by an intermediate step that looks up the day task. A `TODO` comment is added to remove this legacy step once `DayNote` knows the ID of the day whose note it's displaying.

I've also added a test suite for `DayNote`.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
