### PR TITLE
Load task note directly from database

### DIFF
--- a/app/assets/js/src/components/days/DayNote.tsx
+++ b/app/assets/js/src/components/days/DayNote.tsx
@@ -33,7 +33,7 @@ export function DayNote(props: DayNoteProps): JSX.Element {
 	const { name } = day;
 
 	const { isLoading } = useContext(OrangeTwistContext);
-	/** Keep a reference to the note for immediate saving before re-renredering. */
+	/** Keep a reference to the note for immediate saving before re-rendering. */
 	const noteRef = useRef(day.note);
 	// Make sure to update the ref if the task note changes from other sources
 	useEffect(() => {

--- a/app/assets/js/src/components/shared/Notice.tsx
+++ b/app/assets/js/src/components/shared/Notice.tsx
@@ -6,11 +6,11 @@ import {
 	type EnumTypeOf,
 } from 'utils';
 
-const NoticeVariant = {
+export const NoticeVariant = {
 	ERROR: 'error',
 	WARNING: 'warning',
 } as const;
-type NoticeVariant = EnumTypeOf<typeof NoticeVariant>;
+export type NoticeVariant = EnumTypeOf<typeof NoticeVariant>;
 
 interface NoticeProps {
 	variant?: NoticeVariant;

--- a/app/assets/js/src/components/shared/index.ts
+++ b/app/assets/js/src/components/shared/index.ts
@@ -9,4 +9,4 @@ export { Loader } from './Loader';
 export { Markdown } from './Markdown';
 export { Modal } from './Modal';
 export { Note } from './Note';
-export { Notice } from './Notice';
+export { Notice, NoticeVariant } from './Notice';

--- a/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/DayTaskNote.tsx
@@ -26,7 +26,7 @@ export function DayTaskNote(props: DayTaskNoteProps): JSX.Element {
 	const { dayName, taskId } = dayTask;
 
 	const { isLoading } = useContext(OrangeTwistContext);
-	/** Keep a reference to the note for immediate saving before re-renredering. */
+	/** Keep a reference to the note for immediate saving before re-rendering. */
 	const noteRef = useRef(dayTask.note);
 	// Make sure to update the ref if the day task note changes from other sources
 	useEffect(() => {

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.test.tsx
@@ -17,25 +17,27 @@ import {
 	createTask,
 	setDayTaskInfo,
 } from 'data';
+import { createTestData } from 'database';
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import { TaskDetail } from './TaskDetail';
 
 describe('TaskDetail', () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		clear();
+		await createTestData();
 	});
 
 	afterEach(() => {
 		cleanup();
 	});
 
-	test('renders the task\'s note', () => {
+	test('renders the task\'s note', async () => {
 		const taskId = createTask({
 			note: 'Task note',
 		});
 
-		const { getByText } = render(<OrangeTwistContext.Provider
+		const { findByText } = render(<OrangeTwistContext.Provider
 			value={{
 				isLoading: false,
 			}}
@@ -43,7 +45,7 @@ describe('TaskDetail', () => {
 			<TaskDetail taskId={taskId} />
 		</OrangeTwistContext.Provider>);
 
-		expect(getByText('Task note')).toBeInTheDocument();
+		expect(await findByText('Test task 1 note')).toBeInTheDocument();
 	});
 
 	test('renders the status and day name for day tasks', () => {

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskDetail.tsx
@@ -24,6 +24,7 @@ import {
 	Loader,
 	Markdown,
 	Notice,
+	NoticeVariant,
 } from 'components/shared';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
@@ -99,6 +100,7 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 	if (!taskInfo) {
 		return <Notice
 			message={`No task with ID ${taskId} exists`}
+			variant={NoticeVariant.ERROR}
 		/>;
 	}
 
@@ -107,7 +109,7 @@ export function TaskDetail(props: TaskDetailProps): JSX.Element | null {
 			content={`## ${taskInfo.name}`}
 			inline
 		/>
-		<TaskNote task={taskInfo} />
+		<TaskNote taskId={taskInfo.id} />
 		{dayTasksInfo.map((dayTaskInfo, i, arr) => (
 			<DayTaskDetail
 				key={dayTaskInfo.dayName}

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
@@ -19,7 +19,7 @@ import { addCommandListener, registerCommand } from 'registers/commands';
 
 import { clear } from 'data';
 
-import { SaveType } from 'database';
+import { createTestData, SaveType } from 'database';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
@@ -30,32 +30,25 @@ describe('TaskNote', () => {
 		registerCommand(Command.DATA_SAVE, { name: 'Save data' });
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		clear();
+		await createTestData();
 	});
 
 	afterEach(() => {
 		cleanup();
 	});
 
-	test('renders the task\'s note', () => {
-		const { getByText } = render(<OrangeTwistContext.Provider
+	test('renders the task\'s note', async () => {
+		const { findByText } = render(<OrangeTwistContext.Provider
 			value={{
 				isLoading: false,
 			}}
 		>
-			<TaskNote
-				task={{
-					id: 1,
-					name: 'Test task',
-					note: 'Task note',
-					status: 'todo',
-					sortIndex: 1,
-				}}
-			/>
+			<TaskNote taskId={1} />
 		</OrangeTwistContext.Provider>);
 
-		expect(getByText('Task note')).toBeInTheDocument();
+		expect(await findByText('Test task 1 note')).toBeInTheDocument();
 	});
 
 	test('saves note after change', async () => {
@@ -68,23 +61,15 @@ describe('TaskNote', () => {
 
 		addCommandListener(Command.DATA_SAVE, spy, { signal });
 
-		const { getByRole } = render(<OrangeTwistContext.Provider
+		const { findAllByRole } = render(<OrangeTwistContext.Provider
 			value={{
 				isLoading: false,
 			}}
 		>
-			<TaskNote
-				task={{
-					id: 1,
-					name: 'Test task',
-					note: 'Task note',
-					status: 'todo',
-					sortIndex: 1,
-				}}
-			/>
+			<TaskNote taskId={1} />
 		</OrangeTwistContext.Provider>);
 
-		const noteEditButton = getByRole('button', { name: 'Edit note' });
+		const noteEditButton = (await findAllByRole('button', { name: 'Edit note' }))[0];
 		await user.click(noteEditButton);
 		await user.keyboard(' edited');
 
@@ -96,7 +81,7 @@ describe('TaskNote', () => {
 		expect(spy).toHaveBeenCalledWith([{
 			type: SaveType.TASK,
 			id: 1,
-			task: { note: 'Task note edited' },
+			task: { note: 'Test task 1 note edited' },
 		}]);
 
 		controller.abort();

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
@@ -22,6 +22,7 @@ import { clear } from 'data';
 import { createTestData, SaveType } from 'database';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
+import { OrangeTwist } from 'components/OrangeTwist';
 
 import { TaskNote } from './TaskNote';
 
@@ -85,5 +86,30 @@ describe('TaskNote', () => {
 		}]);
 
 		controller.abort();
+	});
+
+	test('reloads note data after change', async () => {
+
+		const user = userEvent.setup();
+
+		const {
+			findAllByRole,
+			findByText,
+		} = render(
+			// Render the full <OrangeTwist> wrapper so it implements saving
+			<OrangeTwist>
+				<TaskNote taskId={1} />
+			</OrangeTwist>
+		);
+
+		expect(await findByText('Test task 1 note')).toBeInTheDocument();
+
+		const noteEditButton = (await findAllByRole('button', { name: 'Edit note' }))[0];
+		await user.click(noteEditButton);
+		await user.keyboard(' edited');
+
+		await user.click(document.body);
+
+		expect(await findByText('Test task 1 note edited')).toBeInTheDocument();
 	});
 });

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.test.tsx
@@ -89,7 +89,6 @@ describe('TaskNote', () => {
 	});
 
 	test('reloads note data after change', async () => {
-
 		const user = userEvent.setup();
 
 		const {

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -91,10 +91,7 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 	return <>
 		{isLoading
 			? <Loader />
-			: (
-				taskAsyncState.type === AsyncDataStateType.SUCCESS &&
-				taskAsyncState.data
-			)
+			: taskAsyncState.type === AsyncDataStateType.SUCCESS
 				? <Note
 					class="task-detail__note"
 					note={optimisticTaskNote}

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -8,6 +8,7 @@ import {
 	useContext,
 	useEffect,
 	useRef,
+	useState,
 } from 'preact/hooks';
 
 import { AsyncDataStateType } from 'utils';
@@ -43,6 +44,11 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 		taskAsyncState.type === AsyncDataStateType.LOADING;
 
 	/**
+	 * A copy of the task note that is updated optimistically on save for immediate display.
+	 */
+	const [optimisticTaskNote, setOptimisticTaskNote] = useState('');
+
+	/**
 	 * Keep a reference to the note for immediate saving of the new value before re-rendering.
 	 */
 	const noteRef = useRef('');
@@ -51,6 +57,7 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 	useEffect(() => {
 		if (taskAsyncState.type === AsyncDataStateType.SUCCESS) {
 			noteRef.current = taskAsyncState.data?.note ?? '';
+			setOptimisticTaskNote(noteRef.current);
 		} else {
 			noteRef.current = '';
 		}
@@ -59,6 +66,7 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 	const setTaskNote = useCallback(
 		(note: string) => {
 			noteRef.current = note;
+			setOptimisticTaskNote(note);
 			setTaskInfo(taskId, { note });
 		},
 		[taskId]
@@ -89,7 +97,7 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 			)
 				? <Note
 					class="task-detail__note"
-					note={taskAsyncState.data.note}
+					note={optimisticTaskNote}
 					onNoteChange={setTaskNote}
 					saveChanges={saveChanges}
 					markdownApiRef={markdownApiRef}

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -42,7 +42,7 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 		taskAsyncState.type === AsyncDataStateType.INITIAL ||
 		taskAsyncState.type === AsyncDataStateType.LOADING;
 
-	/** Keep a reference to the note for immediate saving before re-renredering. */
+	/** Keep a reference to the note for immediate saving before re-rendering. */
 	const noteRef = useRef('');
 	// Make sure to update the ref if the task note changes from other sources
 	useEffect(() => {

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -1,4 +1,8 @@
-import { h, type JSX } from 'preact';
+import {
+	h,
+	Fragment,
+	type JSX,
+} from 'preact';
 import {
 	useCallback,
 	useContext,
@@ -6,47 +10,64 @@ import {
 	useRef,
 } from 'preact/hooks';
 
+import { AsyncDataStateType } from 'utils';
+
 import { fireCommand } from 'registers/commands';
 import { Command } from 'types/Command';
 
-import { setTaskInfo, type TaskInfo } from 'data';
-import { SaveType } from 'database';
+import { setTaskInfo } from 'data';
+import { SaveType, useTask } from 'database';
 
 import { OrangeTwistContext } from 'components/OrangeTwistContext';
 
 import type { MarkdownApi } from 'components/shared/Markdown';
-import { Note } from 'components/shared';
+import {
+	Loader,
+	Note,
+	Notice,
+	NoticeVariant,
+} from 'components/shared';
 
 interface TaskNoteProps {
-	task: Readonly<TaskInfo>;
+	taskId: number;
 }
 
 export function TaskNote(props: TaskNoteProps): JSX.Element {
-	const { task } = props;
+	const { taskId } = props;
 
-	const { isLoading } = useContext(OrangeTwistContext);
+	const taskAsyncState = useTask(taskId);
+
+	const context = useContext(OrangeTwistContext);
+	const isLoading = context.isLoading ||
+		taskAsyncState.type === AsyncDataStateType.INITIAL ||
+		taskAsyncState.type === AsyncDataStateType.LOADING;
+
 	/** Keep a reference to the note for immediate saving before re-renredering. */
-	const noteRef = useRef(task.note);
+	const noteRef = useRef('');
 	// Make sure to update the ref if the task note changes from other sources
 	useEffect(() => {
-		noteRef.current = task.note;
-	}, [task.note]);
+		if (taskAsyncState.type === AsyncDataStateType.SUCCESS) {
+			noteRef.current = taskAsyncState.data?.note ?? '';
+		} else {
+			noteRef.current = '';
+		}
+	}, [taskAsyncState]);
 
 	const setTaskNote = useCallback(
 		(note: string) => {
 			noteRef.current = note;
-			setTaskInfo(task.id, { note });
+			setTaskInfo(taskId, { note });
 		},
-		[task.id]
+		[taskId]
 	);
 
 	const saveChanges = useCallback(() => {
 		fireCommand(Command.DATA_SAVE, [{
 			type: SaveType.TASK,
-			id: task.id,
+			id: taskId,
 			task: { note: noteRef.current },
 		}]);
-	}, [task.id]);
+	}, [taskId]);
 
 	const markdownApiRef = useRef<MarkdownApi | null>(null);
 	// When data is finished loading re-render Markdown
@@ -56,11 +77,24 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 		}
 	}, [isLoading]);
 
-	return <Note
-		class="task-detail__note"
-		note={task.note}
-		onNoteChange={setTaskNote}
-		saveChanges={saveChanges}
-		markdownApiRef={markdownApiRef}
-	/>;
+	return <>
+		{isLoading
+			? <Loader />
+			: (
+				taskAsyncState.type === AsyncDataStateType.SUCCESS &&
+				taskAsyncState.data
+			)
+				? <Note
+					class="task-detail__note"
+					note={taskAsyncState.data.note}
+					onNoteChange={setTaskNote}
+					saveChanges={saveChanges}
+					markdownApiRef={markdownApiRef}
+				/>
+				: <Notice
+					message={`No task with ID ${taskId} exists`}
+					variant={NoticeVariant.ERROR}
+				/>
+		}
+	</>;
 }

--- a/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
+++ b/app/assets/js/src/components/tasks/TaskDetail/TaskNote.tsx
@@ -42,9 +42,12 @@ export function TaskNote(props: TaskNoteProps): JSX.Element {
 		taskAsyncState.type === AsyncDataStateType.INITIAL ||
 		taskAsyncState.type === AsyncDataStateType.LOADING;
 
-	/** Keep a reference to the note for immediate saving before re-rendering. */
+	/**
+	 * Keep a reference to the note for immediate saving of the new value before re-rendering.
+	 */
 	const noteRef = useRef('');
-	// Make sure to update the ref if the task note changes from other sources
+
+	// Make sure to update the note each time the task is loaded
 	useEffect(() => {
 		if (taskAsyncState.type === AsyncDataStateType.SUCCESS) {
 			noteRef.current = taskAsyncState.data?.note ?? '';

--- a/app/assets/js/src/database/access/hooks/index.ts
+++ b/app/assets/js/src/database/access/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useTask } from './useTask';

--- a/app/assets/js/src/database/access/hooks/useTask.ts
+++ b/app/assets/js/src/database/access/hooks/useTask.ts
@@ -14,7 +14,7 @@ import { loadTask } from '../loadTask';
 import { addTaskChangeListener } from '../liveAccessManager';
 
 /**
- * Attempts to load a specified task immediately, and provides a {@linkcode AsyncDataState} representing the state of that loading operation.
+ * Attempts to load a specified task immediately, and reloads it if it is changed in the database. Provides a {@linkcode AsyncDataState} representing the state of that loading operation.
  *
  * @see {@linkcode useAsyncData}
  */

--- a/app/assets/js/src/database/access/hooks/useTask.ts
+++ b/app/assets/js/src/database/access/hooks/useTask.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect } from 'preact/hooks';
+
+import {
+	useAsyncData,
+	type AsyncDataState,
+} from 'utils';
+
+import { loadTask } from '../loadTask';
+
+/**
+ * Attempts to load a specified task immediately, and provides a {@linkcode AsyncDataState} representing the state of that loading operation.
+ *
+ * @see {@linkcode useAsyncData}
+ */
+export function useTask(taskId: number): AsyncDataState<
+	Awaited<ReturnType<typeof getTask>>
+> {
+	const getTask = useCallback(() => {
+		return loadTask(taskId);
+	}, [taskId]);
+
+	const asyncDataResult = useAsyncData(getTask);
+
+	useEffect(
+		() => {
+			const controller = new AbortController();
+			const { signal } = controller;
+
+			asyncDataResult.getData({ signal });
+
+			return () => controller.abort();
+		},
+		// Deliberately only fetch data (or abort prior fetches) if `getTask` changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[getTask]
+	);
+
+	return asyncDataResult.state;
+}

--- a/app/assets/js/src/database/access/hooks/useTask.ts
+++ b/app/assets/js/src/database/access/hooks/useTask.ts
@@ -1,9 +1,11 @@
 import {
 	useCallback,
 	useEffect,
+	useRef,
 } from 'preact/hooks';
 
 import {
+	AsyncDataStateType,
 	useAsyncData,
 	type AsyncDataState,
 } from 'utils';
@@ -53,5 +55,11 @@ export function useTask(taskId: number): AsyncDataState<
 		return () => controller.abort();
 	}, [taskId, asyncDataResult.getData]);
 
-	return asyncDataResult.state;
+	// Don't re-enter loading state on re-requesting data
+	const asyncDataResultStateRef = useRef(asyncDataResult.state);
+	if (asyncDataResult.state.type !== AsyncDataStateType.LOADING) {
+		asyncDataResultStateRef.current = asyncDataResult.state;
+	}
+
+	return asyncDataResultStateRef.current;
 }

--- a/app/assets/js/src/database/access/hooks/useTask.ts
+++ b/app/assets/js/src/database/access/hooks/useTask.ts
@@ -1,4 +1,7 @@
-import { useCallback, useEffect } from 'preact/hooks';
+import {
+	useCallback,
+	useEffect,
+} from 'preact/hooks';
 
 import {
 	useAsyncData,
@@ -6,6 +9,7 @@ import {
 } from 'utils';
 
 import { loadTask } from '../loadTask';
+import { addTaskChangeListener } from '../liveAccessManager';
 
 /**
  * Attempts to load a specified task immediately, and provides a {@linkcode AsyncDataState} representing the state of that loading operation.
@@ -34,6 +38,20 @@ export function useTask(taskId: number): AsyncDataState<
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[getTask]
 	);
+
+	// Re-fetch the data if it changes
+	useEffect(() => {
+		const controller = new AbortController();
+		const { signal } = controller;
+
+		addTaskChangeListener(
+			taskId,
+			asyncDataResult.getData,
+			{ signal },
+		);
+
+		return () => controller.abort();
+	}, [taskId, asyncDataResult.getData]);
 
 	return asyncDataResult.state;
 }

--- a/app/assets/js/src/database/access/index.ts
+++ b/app/assets/js/src/database/access/index.ts
@@ -1,2 +1,5 @@
 export { save } from './save';
 export { SaveType, type SaveAction } from './SaveAction';
+
+export { loadTask } from './loadTask';
+export { useTask } from './hooks/useTask';

--- a/app/assets/js/src/database/access/liveAccessManager.test.ts
+++ b/app/assets/js/src/database/access/liveAccessManager.test.ts
@@ -1,0 +1,30 @@
+import {
+	describe,
+	expect,
+	jest,
+	test,
+} from '@jest/globals';
+
+import {
+	addTaskChangeListener,
+	noticeTaskChange,
+	removeTaskChangeListener,
+} from './liveAccessManager';
+
+describe('liveAccessManager', () => {
+	test('listens for changes based on task ID', () => {
+		const listener = jest.fn();
+
+		addTaskChangeListener(1, listener);
+
+		noticeTaskChange(2);
+		expect(listener).toHaveBeenCalledTimes(0);
+
+		noticeTaskChange(1);
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		removeTaskChangeListener(1, listener);
+		noticeTaskChange(1);
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/assets/js/src/database/access/liveAccessManager.ts
+++ b/app/assets/js/src/database/access/liveAccessManager.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal record of {@linkcode EventTarget}s for various observable objects.
+ */
+export const eventTargetLookup = {
+	task: new Map<number, EventTarget>(),
+};
+
+/**
+ * Trigger a "change" event for a specified task, causing any change listeners for that task to fire.
+ */
+export function noticeTaskChange(taskId: number): void {
+	const taskChangeTarget = eventTargetLookup.task.get(taskId);
+	if (!taskChangeTarget) {
+		return;
+	}
+
+	taskChangeTarget.dispatchEvent(new Event('change'));
+}
+
+/**
+ * Adds a "change" listener for a specified task.
+ */
+export function addTaskChangeListener(
+	taskId: number,
+	callback: () => void,
+	options?: AddEventListenerOptions,
+): void {
+	const taskChangeTarget = eventTargetLookup.task.getOrInsert(
+		taskId,
+		new EventTarget(),
+	);
+
+	taskChangeTarget.addEventListener('change', callback, options);
+}
+
+/**
+ * Removes a "change" listener for a specified task.
+ */
+export function removeTaskChangeListener(
+	taskId: number,
+	callback: () => void,
+): void {
+	const taskChangeTarget = eventTargetLookup.task.get(taskId);
+	if (!taskChangeTarget) {
+		return;
+	}
+
+	taskChangeTarget.removeEventListener('change', callback);
+}

--- a/app/assets/js/src/database/access/loadTask.ts
+++ b/app/assets/js/src/database/access/loadTask.ts
@@ -1,0 +1,14 @@
+import { ObjectStoreName } from '../metadata';
+import { getTaskInternal } from '../internal';
+import { requestTransaction } from './requestTransaction';
+
+/**
+ * Loads data from a single task.
+ */
+export async function loadTask(id: number): ReturnType<typeof getTaskInternal> {
+	const transaction = await requestTransaction([ObjectStoreName.TASK], 'readonly');
+
+	const task = await getTaskInternal(transaction, id);
+
+	return task;
+}

--- a/app/assets/js/src/database/access/save.ts
+++ b/app/assets/js/src/database/access/save.ts
@@ -12,6 +12,7 @@ import {
 
 import { SaveType, type SaveAction } from './SaveAction';
 import { requestTransaction } from './requestTransaction';
+import { noticeTaskChange } from './liveAccessManager';
 
 /**
  * Process any number of {@linkcode SaveAction}s.
@@ -68,6 +69,7 @@ async function saveTask(
 	}
 
 	await updateTaskInternal(transaction, taskToSave);
+	noticeTaskChange(action.id);
 }
 
 /**

--- a/app/assets/js/src/database/index.ts
+++ b/app/assets/js/src/database/index.ts
@@ -1,2 +1,11 @@
 export { adapterV1, dbV1 } from './adapterV1';
-export { save, SaveType, type SaveAction } from './access';
+export {
+	save,
+	SaveType,
+	type SaveAction,
+
+	loadTask,
+	useTask,
+} from './access';
+
+export { createTestData } from './test-utils';

--- a/app/assets/js/src/utils/animate/animate.test.ts
+++ b/app/assets/js/src/utils/animate/animate.test.ts
@@ -1,21 +1,12 @@
 import {
-	afterAll,
-	afterEach,
 	describe,
 	expect,
 	test,
 } from '@jest/globals';
-import { configMocks, mockAnimationsApi } from 'jsdom-testing-mocks';
 
 import { CSSKeyframes } from '../CSSKeyframes';
 
-import { animate } from '.';
-
-configMocks({
-	afterEach,
-	afterAll,
-});
-mockAnimationsApi();
+import { animate } from './animate';
 
 describe('animate', () => {
 	test('returns an Animation', () => {

--- a/app/assets/js/src/utils/index.ts
+++ b/app/assets/js/src/utils/index.ts
@@ -34,7 +34,12 @@ export { sortElementsBySortIndex } from './sortElementsBySortIndex';
 export { startAnimationLoop } from './startAnimationLoop';
 export { strMatch, type StrMatchOptions } from './strMatch';
 export { tryStartViewTransition } from './tryStartViewTransition';
-export { useAsyncData, type AsyncDataState } from './useAsyncData';
+export {
+	useAsyncData,
+	type AsyncDataState,
+	AsyncDataStateType,
+	type AsyncDataResult,
+} from './useAsyncData';
 export { useBlurCallback } from './useBlurCallback';
 export { useCloseWatcher } from './useCloseWatcher';
 export { usePropAsRef } from './usePropAsRef';

--- a/app/assets/js/src/utils/useAsyncData.test.ts
+++ b/app/assets/js/src/utils/useAsyncData.test.ts
@@ -10,27 +10,46 @@ import {
 } from '@testing-library/preact';
 
 import {
-	AsyncDataState,
+	AsyncDataStateType,
 	useAsyncData,
 	type GetAsyncDataOptions,
 } from './useAsyncData';
 
 describe('useAsyncData', () => {
-	test('returns an AsyncDataState', () => {
+	test('starts in an initial state', () => {
 		const { result } = renderHook(
 			() => useAsyncData(
 				() => new Promise(() => {})
 			)
 		);
 
-		expect(result.current).toMatchObject({
-			state: AsyncDataState.LOADING,
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.INITIAL,
+		});
+	});
+
+	test('enters loading state when data is requested', () => {
+		const initialProps = {
+			getData: () => new Promise(() => {}),
+		};
+		const { result, rerender } = renderHook(
+			({ getData }) => useAsyncData(getData),
+			{ initialProps },
+		);
+
+		result.current.getData();
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
 		});
 	});
 
 	test('makes data available when Promise is settled', async () => {
-		let resolveData: (value: unknown) => void;
-		const dataPromise = new Promise((resolve) => resolveData = resolve);
+		const {
+			resolve: resolveData,
+			promise: dataPromise,
+		} = Promise.withResolvers<unknown>();
 		const initialProps = {
 			getData: () => dataPromise,
 		};
@@ -41,42 +60,27 @@ describe('useAsyncData', () => {
 		);
 
 		const data = Math.random();
-		await act(() => resolveData!(data));
-		// TODO: Can I refactor it to not need an additional rerender?
-		await act(() => rerender(initialProps));
 
-		expect(result.current).toMatchObject({
-			state: AsyncDataState.SUCCESS,
+		result.current.getData();
+		rerender(initialProps);
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
+		});
+
+		await act(() => resolveData(data));
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.SUCCESS,
 			data,
 		});
 	});
 
-	test('passes an AbortSignal to get callback, and aborts it if unmounted', () => {
-		let abortSignal: AbortSignal | undefined;
-		const initialProps = {
-			getData: (options?: GetAsyncDataOptions) => new Promise(() => {
-				abortSignal = options?.signal;
-			}),
-		};
-
-		const { result, unmount } = renderHook(
-			({ getData }) => useAsyncData(getData),
-			{ initialProps }
-		);
-
-		expect(result.current).toMatchObject({
-			state: AsyncDataState.LOADING,
-		});
-		expect(abortSignal!.aborted).toBe(false);
-
-		unmount();
-
-		expect(abortSignal!.aborted).toBe(true);
-	});
-
 	test('resolves with error when Promise is rejected', async () => {
-		let rejectWithError: (value: unknown) => void;
-		const dataPromise = new Promise((resolve, reject) => rejectWithError = reject);
+		const {
+			reject: rejectWithError,
+			promise: dataPromise,
+		} = Promise.withResolvers<never>();
 		const initialProps = {
 			getData: () => dataPromise,
 		};
@@ -86,13 +90,146 @@ describe('useAsyncData', () => {
 			{ initialProps }
 		);
 
-		const error = new Error('Failed to fetch');
-		await act(() => rejectWithError!(error));
-		// TODO: Can I refactor it to not need an additional rerender?
-		await act(() => rerender(initialProps));
+		result.current.getData()
+			.catch(() => {
+				// Do nothing on error, but consider it handled
+			});
 
-		expect(result.current).toMatchObject({
-			state: AsyncDataState.ERROR,
+		const error = new Error('Failed to fetch');
+		await act(() => rejectWithError(error));
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.ERROR,
+			error,
+		});
+	});
+
+	test('aborts any previous attempts when starting a new one', () => {
+		let abortSignal: AbortSignal;
+		const initialProps = {
+			getData: (options?: GetAsyncDataOptions) => new Promise(() => {
+				abortSignal = abortSignal ?? options!.signal;
+			}),
+		};
+		const { result, rerender } = renderHook(
+			({ getData }) => useAsyncData(getData),
+			{ initialProps }
+		);
+
+		result.current.getData();
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
+		});
+		expect(abortSignal!.aborted).toBe(false);
+
+		result.current.getData();
+		rerender(initialProps);
+
+		expect(abortSignal!.aborted).toBe(true);
+	});
+
+	test('enters aborted state if aborted before reaching success or error states', () => {
+		const {
+			promise,
+		} = Promise.withResolvers();
+		const initialProps = {
+			getData: () => promise,
+		};
+		const { result, rerender } = renderHook(
+			({ getData }) => useAsyncData(getData),
+			{ initialProps }
+		);
+
+		const abortController = new AbortController();
+		const { signal } = abortController;
+
+		result.current.getData({ signal });
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
+		});
+
+		abortController.abort('Manually aborted');
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.ABORTED,
+			reason: 'Manually aborted',
+		});
+	});
+
+	test('does not enter aborted state if aborted after reaching success state', async () => {
+		const {
+			promise,
+			resolve,
+		} = Promise.withResolvers();
+		const initialProps = {
+			getData: () => promise,
+		};
+		const { result, rerender } = renderHook(
+			({ getData }) => useAsyncData(getData),
+			{ initialProps }
+		);
+
+		const abortController = new AbortController();
+		const { signal } = abortController;
+
+		result.current.getData({ signal });
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
+		});
+
+		await act(() => resolve('Data'));
+
+		abortController.abort('Manually aborted');
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.SUCCESS,
+			data: 'Data',
+		});
+	});
+
+	test('does not enter aborted state if aborted after reaching error state', async () => {
+		const {
+			promise,
+			reject,
+		} = Promise.withResolvers();
+		const initialProps = {
+			getData: () => promise,
+		};
+		const { result, rerender } = renderHook(
+			({ getData }) => useAsyncData(getData),
+			{ initialProps }
+		);
+
+		const abortController = new AbortController();
+		const { signal } = abortController;
+
+		result.current.getData({ signal })
+			.catch(() => {
+				// Do nothing on error
+			});
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.LOADING,
+		});
+
+		const error = new Error('Error');
+		await act(() => reject(error));
+
+		abortController.abort('Manually aborted');
+		rerender(initialProps);
+
+		expect(result.current.state).toMatchObject({
+			type: AsyncDataStateType.ERROR,
 			error,
 		});
 	});

--- a/app/assets/js/src/utils/useAsyncData.test.ts
+++ b/app/assets/js/src/utils/useAsyncData.test.ts
@@ -9,8 +9,11 @@ import {
 	renderHook,
 } from '@testing-library/preact';
 
-import type { GetAsyncDataOptions } from './useAsyncData';
-import { useAsyncData } from './useAsyncData';
+import {
+	AsyncDataState,
+	useAsyncData,
+	type GetAsyncDataOptions,
+} from './useAsyncData';
 
 describe('useAsyncData', () => {
 	test('returns an AsyncDataState', () => {
@@ -21,9 +24,7 @@ describe('useAsyncData', () => {
 		);
 
 		expect(result.current).toMatchObject({
-			data: null,
-			isLoading: true,
-			error: null,
+			state: AsyncDataState.LOADING,
 		});
 	});
 
@@ -45,9 +46,8 @@ describe('useAsyncData', () => {
 		await act(() => rerender(initialProps));
 
 		expect(result.current).toMatchObject({
+			state: AsyncDataState.SUCCESS,
 			data,
-			isLoading: false,
-			error: null,
 		});
 	});
 
@@ -65,9 +65,7 @@ describe('useAsyncData', () => {
 		);
 
 		expect(result.current).toMatchObject({
-			data: null,
-			isLoading: true,
-			error: null,
+			state: AsyncDataState.LOADING,
 		});
 		expect(abortSignal!.aborted).toBe(false);
 
@@ -88,15 +86,14 @@ describe('useAsyncData', () => {
 			{ initialProps }
 		);
 
-		const errorMessage = 'Failed to fetch';
-		await act(() => rejectWithError!(new Error(errorMessage)));
+		const error = new Error('Failed to fetch');
+		await act(() => rejectWithError!(error));
 		// TODO: Can I refactor it to not need an additional rerender?
 		await act(() => rerender(initialProps));
 
 		expect(result.current).toMatchObject({
-			data: null,
-			isLoading: false,
-			error: errorMessage,
+			state: AsyncDataState.ERROR,
+			error,
 		});
 	});
 });

--- a/app/assets/js/src/utils/useAsyncData.ts
+++ b/app/assets/js/src/utils/useAsyncData.ts
@@ -34,7 +34,7 @@ type AsyncDataStateMap<T> = {
 /**
  * A discriminated union of possible results of async data retrieval.
  */
-type AsyncDataState<T> = {
+export type AsyncDataState<T> = {
 	[S in AsyncDataStateType]: ExpandType<
 		{ type: S; } &
 		AsyncDataStateMap<T>[S]
@@ -97,6 +97,9 @@ export function useAsyncData<T>(
 		return combinedSignal;
 	}, []);
 
+	/**
+	 * A wrapper around the {@linkcode getData} function that manages custom logic such as setting state and sending internal {@linkcode AbortSignal}s.
+	 */
 	const getDataWrapper = useCallback(
 		async (options?: GetAsyncDataOptions) => {
 			// 1. Abort any previous attempts, and configure abort controls for this attempt

--- a/app/assets/js/src/utils/useAsyncData.ts
+++ b/app/assets/js/src/utils/useAsyncData.ts
@@ -1,10 +1,33 @@
 import { useEffect, useState } from 'preact/hooks';
+import type { EnumTypeOf } from './EnumTypeOf';
+import type { ExpandType } from './ExpandType';
 
-export interface AsyncDataState<T> {
-	data: T | null;
-	isLoading: boolean;
-	error: string | null;
-}
+export const AsyncDataState = {
+	LOADING: 'loading',
+	ERROR: 'error',
+	SUCCESS: 'success',
+} as const;
+export type AsyncDataState = EnumTypeOf<typeof AsyncDataState>;
+
+type AsyncDataStateMap<T> = {
+	[AsyncDataState.LOADING]: {};
+	[AsyncDataState.ERROR]: {
+		error: Error;
+	};
+	[AsyncDataState.SUCCESS]: {
+		data: T;
+	};
+};
+
+/**
+ * A discriminated union of possible results of async data retrieval.
+ */
+export type AsyncDataResult<T> = {
+	[S in AsyncDataState]: ExpandType<
+		{ state: S; } &
+		AsyncDataStateMap<T>[S]
+	>;
+}[AsyncDataState];
 
 export interface GetAsyncDataOptions {
 	/**
@@ -16,46 +39,48 @@ export interface GetAsyncDataOptions {
 
 export function useAsyncData<T>(
 	getData: (options?: GetAsyncDataOptions) => Promise<T>,
-): AsyncDataState<T> {
-	const [isLoading, setIsLoading] = useState(true);
-	const [data, setData] = useState<T | null>(null);
-	const [error, setError] = useState<string | null>(null);
+): AsyncDataResult<T> {
+	const [result, setResult] = useState<AsyncDataResult<T>>({ state: AsyncDataState.LOADING });
 
-	useEffect(() => {
-		const controller = new AbortController();
-		const { signal } = controller;
+	useEffect(
+		() => {
+			const controller = new AbortController();
+			const { signal } = controller;
 
-		(async () => {
-			setIsLoading(true);
-			setError(null);
+			(async () => {
+				if (result.state !== AsyncDataState.LOADING) {
+					setResult({ state: AsyncDataState.LOADING });
+				}
 
-			try {
-				const data = await getData({ signal });
-				setData(data);
-			} catch (e) {
-				setData(null);
+				try {
+					const data = await getData({ signal });
+					setResult({
+						state: AsyncDataState.SUCCESS,
+						data,
+					});
+				} catch (e) {
+					const error = (() => {
+						if (e instanceof Error) {
+							return e;
+						} else if (typeof e === 'string') {
+							return new Error(e);
+						} else {
+							return new Error('Encountered unknown error when retrieving async data.', { cause: e });
+						}
+					})();
+					setResult({
+						state: AsyncDataState.ERROR,
+						error,
+					});
+				}
+			})();
 
-				const error = (() => {
-					if (e instanceof Error) {
-						return e.message;
-					} else if (typeof e === 'string') {
-						return e;
-					} else {
-						return String(e);
-					}
-				})();
-				setError(error);
-			} finally {
-				setIsLoading(false);
-			}
-		})();
+			return () => controller.abort();
+		},
+		// Only re-run this hook when the `getData` function changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[getData]
+	);
 
-		return () => controller.abort();
-	}, [getData]);
-
-	return {
-		isLoading,
-		data,
-		error,
-	};
+	return result;
 }

--- a/app/assets/js/src/utils/useAsyncData.ts
+++ b/app/assets/js/src/utils/useAsyncData.ts
@@ -1,20 +1,32 @@
-import { useEffect, useState } from 'preact/hooks';
+import {
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+} from 'preact/hooks';
+
 import type { EnumTypeOf } from './EnumTypeOf';
 import type { ExpandType } from './ExpandType';
 
-export const AsyncDataState = {
+export const AsyncDataStateType = {
+	INITIAL: 'initial',
 	LOADING: 'loading',
+	ABORTED: 'aborted',
 	ERROR: 'error',
 	SUCCESS: 'success',
 } as const;
-export type AsyncDataState = EnumTypeOf<typeof AsyncDataState>;
+export type AsyncDataStateType = EnumTypeOf<typeof AsyncDataStateType>;
 
 type AsyncDataStateMap<T> = {
-	[AsyncDataState.LOADING]: {};
-	[AsyncDataState.ERROR]: {
+	[AsyncDataStateType.INITIAL]: {};
+	[AsyncDataStateType.LOADING]: {};
+	[AsyncDataStateType.ABORTED]: {
+		reason: unknown;
+	};
+	[AsyncDataStateType.ERROR]: {
 		error: Error;
 	};
-	[AsyncDataState.SUCCESS]: {
+	[AsyncDataStateType.SUCCESS]: {
 		data: T;
 	};
 };
@@ -22,12 +34,25 @@ type AsyncDataStateMap<T> = {
 /**
  * A discriminated union of possible results of async data retrieval.
  */
-export type AsyncDataResult<T> = {
-	[S in AsyncDataState]: ExpandType<
-		{ state: S; } &
+type AsyncDataState<T> = {
+	[S in AsyncDataStateType]: ExpandType<
+		{ type: S; } &
 		AsyncDataStateMap<T>[S]
 	>;
-}[AsyncDataState];
+}[AsyncDataStateType];
+
+export type AsyncDataResult<T> = {
+	/** The current state of the async data. */
+	state: AsyncDataState<T>;
+	/**
+	 * A getter function to retrieve async data.
+	 *
+	 * @param options An optional set of configuration options.
+	 *
+	 * @throws Error if an error is encountered when retrieving data.
+	 */
+	getData: (options?: GetAsyncDataOptions) => Promise<T>;
+};
 
 export interface GetAsyncDataOptions {
 	/**
@@ -37,50 +62,109 @@ export interface GetAsyncDataOptions {
 	signal: AbortSignal;
 }
 
+/**
+ * Provides a getter function for asynchronous data, as well as an automatically updated state object that can be used to handle states like loading and error.
+ *
+ * @param getData A function that retrieves data asynchronously. Will be passed an {@linkcode AbortSignal} that will be aborted if a subsequent request is made, or if an external {@linkcode AbortSignal} provided to the returned getter is aborted.
+ */
 export function useAsyncData<T>(
-	getData: (options?: GetAsyncDataOptions) => Promise<T>,
+	getData: (options: GetAsyncDataOptions) => Promise<T>,
 ): AsyncDataResult<T> {
-	const [result, setResult] = useState<AsyncDataResult<T>>({ state: AsyncDataState.LOADING });
+	const [state, setState] = useState<AsyncDataState<T>>({ type: AsyncDataStateType.INITIAL });
 
-	useEffect(
-		() => {
-			const controller = new AbortController();
-			const { signal } = controller;
+	const abortControllerRef = useRef(new AbortController());
 
-			(async () => {
-				if (result.state !== AsyncDataState.LOADING) {
-					setResult({ state: AsyncDataState.LOADING });
+	/**
+	 * Abort any previous data requests, and reset the internal {@linkcode AbortController}.
+	 */
+	const abortPrevious = useCallback(() => {
+		abortControllerRef.current.abort();
+		abortControllerRef.current = new AbortController();
+	}, []);
+
+	/**
+	 * Construct a combined {@linkcode AbortSignal} from both internal sources and optional external sources passed in as options.
+	 */
+	const getCombinedAbortSignal = useCallback((options?: GetAsyncDataOptions) => {
+		const internalSignal = abortControllerRef.current.signal;
+		const externalSignal = options?.signal;
+
+		const combinedSignal = AbortSignal.any([
+			internalSignal,
+			externalSignal,
+		].filter(Boolean));
+
+		return combinedSignal;
+	}, []);
+
+	const getDataWrapper = useCallback(
+		async (options?: GetAsyncDataOptions) => {
+			// 1. Abort any previous attempts, and configure abort controls for this attempt
+			abortPrevious();
+			const combinedAbortSignal = getCombinedAbortSignal(options);
+
+			// Add abort listeners to enter aborted state if signal is aborted before we reach success or error state
+			const abortSignalUpdateController = new AbortController();
+			const abortSignalUpdateSignal = abortSignalUpdateController.signal;
+
+			combinedAbortSignal.addEventListener(
+				'abort',
+				() => {
+					setState({
+						type: AsyncDataStateType.ABORTED,
+						reason: combinedAbortSignal.reason,
+					});
+				},
+				{
+					signal: abortSignalUpdateSignal,
+				}
+			);
+
+			try {
+				// 2. Enter loading state
+				if (state.type !== AsyncDataStateType.LOADING) {
+					setState({ type: AsyncDataStateType.LOADING });
 				}
 
-				try {
-					const data = await getData({ signal });
-					setResult({
-						state: AsyncDataState.SUCCESS,
-						data,
-					});
-				} catch (e) {
-					const error = (() => {
-						if (e instanceof Error) {
-							return e;
-						} else if (typeof e === 'string') {
-							return new Error(e);
-						} else {
-							return new Error('Encountered unknown error when retrieving async data.', { cause: e });
-						}
-					})();
-					setResult({
-						state: AsyncDataState.ERROR,
-						error,
-					});
-				}
-			})();
-
-			return () => controller.abort();
+				// 3. Attempt to retrieve data
+				const data = await getData({
+					signal: combinedAbortSignal,
+				});
+				// 4a. Handle retrieved data
+				setState({
+					type: AsyncDataStateType.SUCCESS,
+					data,
+				});
+				return data;
+			} catch (e) {
+				// 4b. Handle error retrieving data
+				const error = (() => {
+					if (e instanceof Error) {
+						return e;
+					} else if (typeof e === 'string') {
+						return new Error(e);
+					} else {
+						return new Error('Encountered unknown error when retrieving async data.', { cause: e });
+					}
+				})();
+				setState({
+					type: AsyncDataStateType.ERROR,
+					error,
+				});
+				throw error;
+			} finally {
+				abortSignalUpdateController.abort();
+			}
 		},
-		// Only re-run this hook when the `getData` function changes
+		// Deliberately only rebuild this function when the `getData` function changes
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[getData]
 	);
+
+	const result = useMemo<AsyncDataResult<T>>(() => ({
+		state,
+		getData: getDataWrapper,
+	}), [state, getDataWrapper]);
 
 	return result;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,12 @@ export default defineConfig([
 			},
 		},
 
+		linterOptions: {
+			// Disabling this seems to be the only way to prevent line comments to disable rules from being incorrectly removed on save
+			// https://github.com/microsoft/vscode-eslint/issues/1938
+			reportUnusedDisableDirectives: 'off',
+		},
+
 		plugins: {
 			'@stylistic': stylistic,
 			'@typescript-eslint': typescriptEslint,
@@ -62,7 +68,6 @@ export default defineConfig([
 
 		extends: compat.extends(
 			'eslint:recommended',
-			'plugin:@typescript-eslint/recommended',
 			'plugin:@typescript-eslint/recommended-requiring-type-checking',
 		),
 

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,4 +1,11 @@
-import { beforeAll, jest } from '@jest/globals';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	jest,
+} from '@jest/globals';
+
+import { configMocks, mockAnimationsApi } from 'jsdom-testing-mocks';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -56,7 +63,7 @@ function polyfillDialogElement() {
  * jsdom hasn't implemented window.scrollTo, so replace it
  * with a mocked function so it won't cause JavaScript errors.
  */
-function polyfillWindowScrollto() {
+function mockWindowScrollto() {
 	window.scrollTo = jest.fn();
 }
 
@@ -64,7 +71,7 @@ function polyfillWindowScrollto() {
  * jsdom hasn't implemented Element.scrollIntoView, so replace it
  * with a mocked function so it won't cause JavaScript errors.
  */
-function polyfillElementScrollIntoView() {
+function mockElementScrollIntoView() {
 	window.Element.prototype.scrollIntoView = jest.fn();
 }
 
@@ -88,7 +95,7 @@ class BroadcastChannel {
  * jsdom hasn't implemented the BroadcastChannel API, so replace it
  * with a mocked version so it won't cause JavaScript errors.
  */
-function polyfillBroadcastChannelApi() {
+function mockBroadcastChannelApi() {
 	window.BroadcastChannel = BroadcastChannel;
 }
 
@@ -96,19 +103,25 @@ function polyfillBroadcastChannelApi() {
  * jsdom hasn't implemented the CSS API, so replace it with a mocked
  * version so it won't cause JavaScript errors.
  */
-function polyfillCSS() {
+function mockCSS() {
 	window.CSS = {} as unknown as typeof window.CSS;
 
 	window.CSS.supports = () => true;
 }
 
-polyfillBroadcastChannelApi();
-polyfillCSS();
+mockBroadcastChannelApi();
+mockCSS();
+
+configMocks({
+	afterEach,
+	afterAll,
+});
+mockAnimationsApi();
 
 beforeAll(() => {
 	polyfillDialogElement();
-	polyfillWindowScrollto();
-	polyfillElementScrollIntoView();
+	mockWindowScrollto();
+	mockElementScrollIntoView();
 });
 
 // Define global constants usually replaced using esbuild's "define" option


### PR DESCRIPTION
<!-- Describe the problem being solved -->
As a follow-up to the database migration, I want each UI component to read just the data it needs from the database instead of always working with a full in-memory cache of the entire database.

<!-- Describe your solution -->
This PR updates a previously unused `useAsyncData` hook, and creates a `useTask` hook wrapping it to provide asynchronous access to task information from the database to the `TaskNote` component.

<!-- Complete each item in this pre-merge checklist -->

- [x] The version number has been updated in `package.json`
- [x] A changelog entry has been added for the new version (you can use the date when your PR is published, see [keepachangelog.com](https://keepachangelog.com/) for guidance)
